### PR TITLE
Update cocktail paths, menus, and add new drinks

### DIFF
--- a/src/lib/data/all-paths.ts
+++ b/src/lib/data/all-paths.ts
@@ -18,12 +18,12 @@ export const allPaths: CocktailPath[] = [
 	HUNTER,
 	MAGE,
 	BARD,
-	ROGUE,
 	WARLOCK,
-	INNKEEPER,
+	ROGUE,
+	SHAMAN,
 	FISHERMAN,
-	ROYAL,
-	SHAMAN
+	INNKEEPER,
+	ROYAL
 ];
 
 // Create a map of all paths by slug for quick lookups

--- a/src/lib/data/cocktail-paths/bard.ts
+++ b/src/lib/data/cocktail-paths/bard.ts
@@ -1,8 +1,8 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
 import AMARETTO_SOUR from '../cocktails/amaretto-sour';
 import ESPRESSO_MARTINI from '../cocktails/espresso-martini';
-import LOGGY_CAB from '../cocktails/loggy-cab';
 import MOJITO from '../cocktails/mojito';
+import SIDECAR from '../cocktails/sidecar';
 import SPRITZ from '../cocktails/spritz';
 
 export const BARD: CocktailPath = {
@@ -12,6 +12,6 @@ export const BARD: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/bard.jpeg',
 	description:
-		'The life of the party, one round at a time. This path opens with a breezy gin-and-lime fizz, shifts to cool herbal freshness, nutty sweetness, breezy bubbles, and a bold caffeinated finish. Nothing too challenging, nothing too obscure—just drinks that make everyone at the table happy.',
-	cocktails: [LOGGY_CAB, MOJITO, AMARETTO_SOUR, SPRITZ, ESPRESSO_MARTINI]
+		'The life of the party, one round at a time. This path opens with cool minty refreshment, shifts to breezy bubbles, refined citrus-brandy elegance, nutty sweetness, and a bold caffeinated finish. Nothing too challenging, nothing too obscure—just drinks that make everyone at the table happy.',
+	cocktails: [MOJITO, SPRITZ, SIDECAR, AMARETTO_SOUR, ESPRESSO_MARTINI]
 };

--- a/src/lib/data/cocktail-paths/fisherman.ts
+++ b/src/lib/data/cocktail-paths/fisherman.ts
@@ -7,11 +7,11 @@ import SPAGHETT from '../cocktails/spaghett';
 
 export const FISHERMAN: CocktailPath = {
 	title: 'Fisherman',
-	subtitle: 'Salty. Savory. Shoreline-ready.',
+	subtitle: 'Breezy. Refreshing. Shoreline-ready.',
 	slug: 'fisherman',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/fisherman.jpeg',
 	description:
-		'For those who drink like they live—close to the water. This path starts with muddled citrus simplicity, moves through light beer-and-bitter refreshment, picks up fruity tropical notes, then turns savory and spiced before finishing smoky, peaty, and salt-rimmed.',
+		'Kick off your shoes and unwind by the water. This path starts with muddled citrus simplicity, drifts into light beer-and-bitter refreshment, picks up fruity tropical notes, then cools down with a savory, spiced sipper before finishing with a true sea-worn cocktail—smoky, bold flavors that echo the ocean itself.',
 	cocktails: [CAIPIRINHA, SPAGHETT, LOST_LAKE, MICHELADA, SEA_LEGS]
 };

--- a/src/lib/data/summer-menu.ts
+++ b/src/lib/data/summer-menu.ts
@@ -14,8 +14,9 @@ import SLAP_N_PICKLE from './cocktails/slap-n-pickle';
 import KING_OF_KINGS from './cocktails/king-of-kings';
 import CAIPIRINHA from './cocktails/caipirinha';
 import DEAR_LUKEY from './cocktails/dear-lukey';
+import LOGGY_CAB from './cocktails/loggy-cab';
 
-export const featuredDrinks: Cocktail[] = [GILDED_ROSE];
+export const featuredDrinks: Cocktail[] = [GILDED_ROSE, LOGGY_CAB];
 
 export const categories: Category[] = [
 	{

--- a/src/lib/data/winter-menu.ts
+++ b/src/lib/data/winter-menu.ts
@@ -14,14 +14,15 @@ import ESPRESSO_MARTINI from '$lib/data/cocktails/espresso-martini';
 import CHOCOLATE_COVERED_CHERRIES from '$lib/data/cocktails/chocolate-covered-cherries';
 import RATTLE_SKULL from './cocktails/rattle-skull';
 import PAPER_PLANE from './cocktails/paper-plane';
+import JACK_ROSE from './cocktails/jack-rose';
 
-export const featuredDrinks: Cocktail[] = [CARAMEL_APPLE_SPICE];
+export const featuredDrinks: Cocktail[] = [CARAMEL_APPLE_SPICE, CHOCOLATE_COVERED_CHERRIES];
 
 export const categories: Category[] = [
 	{
 		title: "Mommy's Drinks",
 		bgColors: sectionColors.mommy,
-		cocktails: [HOT_TODDY, MERRY_MULE, CHOCOLATE_COVERED_CHERRIES]
+		cocktails: [HOT_TODDY, MERRY_MULE, PENICILLIN]
 	},
 	{
 		title: "Daddy's Drinks",
@@ -31,7 +32,7 @@ export const categories: Category[] = [
 	{
 		title: "Cyrus' Drinks",
 		bgColors: sectionColors.cyrus,
-		cocktails: [PENICILLIN, RATTLE_SKULL, OAXACA_OLD_FASHIONED]
+		cocktails: [JACK_ROSE, RATTLE_SKULL, OAXACA_OLD_FASHIONED]
 	},
 	{
 		title: "Lucas' Drinks",


### PR DESCRIPTION
## Summary
- Add Dark 'n' Stormy and Hemingway Daiquiri cocktails
- Add Shaman path and update cocktail path lineups and ordering
- Update Bard path (swap Loggy Cab for Sidecar) and Fisherman path descriptions
- Update Singapore Sling recipe and path connector styling
- Update summer and winter menu featured drinks and categories
- Gitignore local Claude settings and document PR workflow

## Test plan
- [ ] Verify all cocktail pages render correctly (`/cocktails/dark-n-stormy`, `/cocktails/hemingway-daiquiri`)
- [ ] Verify paths page and individual path pages render correctly (`/paths/shaman`, `/paths/bard`, `/paths/fisherman`)
- [ ] Verify summer and winter menu pages reflect updated featured drinks and categories
- [ ] Run `npm run build` to confirm no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)