### PR TITLE
fix(cocktails): improve cocktail page header layout and add new cocktails

### DIFF
--- a/src/lib/data/all-cocktails.ts
+++ b/src/lib/data/all-cocktails.ts
@@ -19,6 +19,7 @@ import CERVEZA_Y_TEQUILA from '$lib/data/cocktails/cerveza-y-tequila';
 import CHAMPAGNE_COCKTAIL from '$lib/data/cocktails/champagne-cocktail';
 import CHOCOLATE_COVERED_CHERRIES from '$lib/data/cocktails/chocolate-covered-cherries';
 import COBRAS_FANG from '$lib/data/cocktails/cobras-fang';
+import CONFERENCE from '$lib/data/cocktails/conference';
 import CORN_N_OIL from '$lib/data/cocktails/corn-n-oil';
 import COSMOPOLITAN from '$lib/data/cocktails/cosmopolitan';
 import COUNT_MAST from '$lib/data/cocktails/count-mast';
@@ -27,6 +28,7 @@ import DAIQUIRI from '$lib/data/cocktails/daiquiri';
 import DARK_N_STORMY from '$lib/data/cocktails/dark-n-stormy';
 import DEAR_LUKEY from '$lib/data/cocktails/dear-lukey';
 import DEER_AND_BEER from '$lib/data/cocktails/deer-and-beer';
+import DESERT_DREAMS from '$lib/data/cocktails/desert-dreams';
 import DIVISION_BELL from '$lib/data/cocktails/division-bell';
 import DONGA_PUNCH from '$lib/data/cocktails/donga-punch';
 import DR_FUNK from '$lib/data/cocktails/dr-funk';
@@ -89,6 +91,7 @@ import SANGRIA from '$lib/data/cocktails/sangria';
 import SATURN from '$lib/data/cocktails/saturn';
 import SAZERAC from '$lib/data/cocktails/sazerac';
 import SEA_LEGS from '$lib/data/cocktails/sea-legs';
+import SHARKS_TOOTH from '$lib/data/cocktails/sharks-tooth';
 import SIDECAR from '$lib/data/cocktails/sidecar';
 import SINGAPORE_SLING from '$lib/data/cocktails/singapore-sling';
 import SLAP_N_PICKLE from '$lib/data/cocktails/slap-n-pickle';
@@ -128,6 +131,7 @@ export const allCocktails: Cocktail[] = [
 	CHAMPAGNE_COCKTAIL,
 	CHOCOLATE_COVERED_CHERRIES,
 	COBRAS_FANG,
+	CONFERENCE,
 	CORN_N_OIL,
 	COSMOPOLITAN,
 	COUNT_MAST,
@@ -136,6 +140,7 @@ export const allCocktails: Cocktail[] = [
 	DARK_N_STORMY,
 	DEAR_LUKEY,
 	DEER_AND_BEER,
+	DESERT_DREAMS,
 	DIVISION_BELL,
 	DONGA_PUNCH,
 	DR_FUNK,
@@ -198,6 +203,7 @@ export const allCocktails: Cocktail[] = [
 	SATURN,
 	SAZERAC,
 	SEA_LEGS,
+	SHARKS_TOOTH,
 	SIDECAR,
 	SINGAPORE_SLING,
 	SLAP_N_PICKLE,

--- a/src/lib/data/cocktail-paths/shaman.ts
+++ b/src/lib/data/cocktail-paths/shaman.ts
@@ -1,5 +1,5 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
-import BATANGA from '../cocktails/batanga';
+import DESERT_DREAMS from '../cocktails/desert-dreams';
 import DIVISION_BELL from '../cocktails/division-bell';
 import GILDA from '../cocktails/gilda';
 import MARGARITA from '../cocktails/margarita';
@@ -12,6 +12,6 @@ export const SHAMAN: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/shaman.jpeg',
 	description:
-		'Follow the agave from field to flame. This path starts with a dead-simple tequila-and-cola build, sharpens into the most iconic citrus cocktail on earth, then drifts through tropical pineapple warmth. From there, mezcal enters alongside rum, and by the final pour the smoke stands alone—balanced, bitter, and modern.',
-	cocktails: [BATANGA, MARGARITA, GILDA, TIA_MIA, DIVISION_BELL]
+		'Follow the agave from field to flame. This path opens with the most iconic citrus cocktail on earth, then dreams into passion fruit and a whisper of mezcal, drifts through tropical pineapple warmth, and as mezcal enters alongside rum, the smoke builds until by the final pour it stands alone—balanced, bitter, and modern.',
+	cocktails: [MARGARITA, DESERT_DREAMS, GILDA, TIA_MIA, DIVISION_BELL]
 };

--- a/src/lib/data/cocktails/conference.ts
+++ b/src/lib/data/cocktails/conference.ts
@@ -1,0 +1,71 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+import BRIAN_MILLER from '$lib/data/bartenders/brian-miller';
+
+const CONFERENCE: Cocktail = {
+	title: 'Conference',
+	description: 'Bourbon, rye, calvados, cognac, demerara syrup, angostura and xocolatl bitters.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/conference.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/conference.png',
+	slug: 'conference',
+	createdBy: BRIAN_MILLER,
+	method: CocktailMethod.Stirred,
+	servedIn: ServedIn.DoubleRocksGlass,
+	ice: Ice.LargeCube,
+	hasStraw: false,
+	ingredients: [
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.BaseSpirits.ELIJAH_CRAIG
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.BaseSpirits.RITTENHOUSE
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.BaseSpirits.BOULARD_VSOP
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.BaseSpirits.ST_REMY_VSOP
+		},
+		{
+			amount: '1 tsp',
+			ingredient: Ingredients.Syrups.DEMERARA_SYRUP
+		},
+		{
+			amount: '2 dashes',
+			ingredient: Ingredients.Bitters.ANGOSTURA
+		},
+		{
+			amount: '1 dash',
+			ingredient: Ingredients.Bitters.XOCOLATL
+		},
+		{
+			label: 'Garnish: Orange twist',
+			ingredient: Ingredients.Citrus.ORANGE_GARNISH
+		},
+		{
+			label: 'Garnish: Lemon twist',
+			ingredient: Ingredients.Citrus.LEMON_GARNISH
+		}
+	],
+	tags: [
+		Tags.BaseAlcohol.WHISKEY,
+		Tags.BaseAlcohol.BRANDY,
+		Tags.FlavorProfile.SPICED,
+		Tags.Technique.STIRRED,
+		Tags.Style.SPIRIT_FORWARD,
+		Tags.Origin.MODERN,
+		Tags.ServedIn.DOUBLE_ROCKS_GLASS
+	]
+};
+
+export default CONFERENCE;

--- a/src/lib/data/cocktails/desert-dreams.ts
+++ b/src/lib/data/cocktails/desert-dreams.ts
@@ -1,0 +1,74 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+import AARON_KRAUSS from '../bartenders/aaron-krauss';
+
+const DESERT_DREAMS: Cocktail = {
+	title: 'Desert Dreams',
+	description:
+		'Blanco tequila, mezcal, passion fruit, honey-ginger, lime, chili and xocolatl bitters.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/desert-dreams.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/desert-dreams.png',
+	slug: 'desert-dreams',
+	method: CocktailMethod.Shaken,
+	servedIn: ServedIn.DoubleRocksGlass,
+	createdBy: AARON_KRAUSS,
+	ice: Ice.Crushed,
+	hasStraw: true,
+	ingredients: [
+		{
+			amount: '1.75oz',
+			ingredient: Ingredients.BaseSpirits.CIMARRON_BLANCO
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.BaseSpirits.DEL_MAGUY_VIDA
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Syrups.PASSIONFRUIT_SYRUP
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Syrups.HONEY_GINGER_SYRUP
+		},
+		{
+			amount: '.75oz',
+			ingredient: Ingredients.Citrus.LIME
+		},
+		{
+			amount: '1 dash',
+			ingredient: Ingredients.Bitters.CHILI
+		},
+		{
+			amount: '1 dash',
+			ingredient: Ingredients.Bitters.XOCOLATL
+		},
+		{
+			label: 'Pinch of salt',
+			ingredient: Ingredients.Other.SALT
+		},
+		{
+			label: 'Garnish: Lime shell',
+			ingredient: Ingredients.Citrus.LIME_GARNISH
+		}
+	],
+	tags: [
+		Tags.BaseAlcohol.TEQUILA,
+		Tags.BaseAlcohol.MEZCAL,
+		Tags.FlavorProfile.CITRUS,
+		Tags.FlavorProfile.FRUITY,
+		Tags.FlavorProfile.SPICED,
+		Tags.Technique.SHAKEN,
+		Tags.Style.TIKI,
+		Tags.Origin.ORIGINAL,
+		Tags.ServedIn.DOUBLE_ROCKS_GLASS
+	]
+};
+
+export default DESERT_DREAMS;

--- a/src/lib/data/cocktails/paloma.ts
+++ b/src/lib/data/cocktails/paloma.ts
@@ -7,7 +7,7 @@ import { Ice } from '$lib/enums/ice';
 
 const PALOMA: Cocktail = {
 	title: 'Paloma',
-	description: 'Tequila, grapefruit soda, lime.',
+	description: 'Blanco tequila, grapefruit, lime, agave, soda water, salt.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/paloma.png',
 	thumbnailImagePath:
@@ -23,19 +23,34 @@ const PALOMA: Cocktail = {
 			ingredient: Ingredients.BaseSpirits.CIMARRON_BLANCO
 		},
 		{
-			amount: '4oz',
-			ingredient: Ingredients.Mixers.GRAPEFRUIT_SODA
+			amount: '1.5oz',
+			ingredient: Ingredients.Citrus.GRAPEFRUIT
 		},
 		{
 			amount: '.5oz',
 			ingredient: Ingredients.Citrus.LIME
 		},
 		{
-			label: 'Garnish: Salt rim',
+			amount: '.5oz',
+			ingredient: Ingredients.Syrups.AGAVE_NECTAR
+		},
+		{
+			amount: '2oz',
+			ingredient: Ingredients.Mixers.SODA_WATER
+		},
+		{
+			label: 'Pinch of salt',
 			ingredient: Ingredients.Other.SALT
+		},
+		{
+			label: 'Rim: Coarse sea salt',
+			ingredient: Ingredients.Other.SALT
+		},
+		{
+			label: 'Garnish: Grapefruit wedge',
+			ingredient: Ingredients.Citrus.GRAPEFRUIT_GARNISH
 		}
 	],
-	notes: 'Typically unmeasured. Add tequila, then ice, then lime. Top with soda.',
 	tags: [
 		Tags.BaseAlcohol.TEQUILA,
 		Tags.FlavorProfile.BUBBLY,

--- a/src/lib/data/cocktails/sharks-tooth.ts
+++ b/src/lib/data/cocktails/sharks-tooth.ts
@@ -1,0 +1,70 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+import DONN_THE_BEACHCOMBER from '$lib/data/bartenders/donn-beach';
+
+const SHARKS_TOOTH: Cocktail = {
+	title: "Shark's Tooth",
+	description:
+		'Blended light rum, jamaican rum, lime, pineapple, rich simple syrup, maraschino cherry syrup.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/sharks-tooth.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/sharks-tooth.png',
+	slug: 'sharks-tooth',
+	createdBy: DONN_THE_BEACHCOMBER,
+	method: CocktailMethod.FlashBlended,
+	servedIn: ServedIn.DoubleRocksGlass,
+	ice: Ice.Crushed,
+	hasStraw: true,
+	ingredients: [
+		{
+			amount: '1oz',
+			ingredient: Ingredients.BaseSpirits.PROBITAS
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Citrus.LIME
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Citrus.PINEAPPLE
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Syrups.RICH_SIMPLE_SYRUP
+		},
+		{
+			amount: '1 tsp',
+			ingredient: Ingredients.Syrups.MARASCHINO_CHERRY_SYRUP
+		},
+		{
+			label: 'Sidecar: 1oz Coruba',
+			ingredient: Ingredients.BaseSpirits.CORUBA
+		},
+		{
+			label: 'Garnish: Maraschino cherry',
+			ingredient: Ingredients.Other.MARASCHINO_CHERRY
+		},
+		{
+			label: 'Garnish: Pineapple slice',
+			ingredient: Ingredients.Citrus.PINEAPPLE_GARNISH
+		}
+	],
+	notes:
+		'Flash blend and pour into a mai tai glass. Pour the sidecar in when you’re ready to drink.',
+	tags: [
+		Tags.BaseAlcohol.RUM,
+		Tags.FlavorProfile.CITRUS,
+		Tags.FlavorProfile.FRUITY,
+		Tags.Technique.FLASH_BLENDED,
+		Tags.Style.TIKI,
+		Tags.Origin.CLASSIC,
+		Tags.ServedIn.DOUBLE_ROCKS_GLASS
+	]
+};
+
+export default SHARKS_TOOTH;

--- a/src/lib/data/cocktails/three-dots-and-a-dash.ts
+++ b/src/lib/data/cocktails/three-dots-and-a-dash.ts
@@ -9,7 +9,7 @@ import DONN_THE_BEACHCOMBER from '$lib/data/bartenders/donn-beach';
 const THREE_DOTS_AND_A_DASH: Cocktail = {
 	title: 'Three Dots and a Dash',
 	description:
-		'Aged rhum agricole, blended rum, demerara rum, honey, orange, lime, falernum, allspice dram, angostura bitters.',
+		'Aged rhum agricole, blended rum, demerara rum, honey, dry curaçao, lime, falernum, allspice dram, angostura bitters.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/three-dots-and-a-dash.png',
 	thumbnailImagePath:
@@ -35,15 +35,7 @@ const THREE_DOTS_AND_A_DASH: Cocktail = {
 		},
 		{
 			amount: '.5oz',
-			ingredient: Ingredients.Syrups.HONEY_SYRUP
-		},
-		{
-			amount: '.5oz',
 			ingredient: Ingredients.Liqueurs.DRY_CURACAO
-		},
-		{
-			amount: '.75oz',
-			ingredient: Ingredients.Citrus.LIME
 		},
 		{
 			amount: '.25oz',
@@ -52,6 +44,14 @@ const THREE_DOTS_AND_A_DASH: Cocktail = {
 		{
 			amount: '.25oz',
 			ingredient: Ingredients.Liqueurs.ALLSPICE_DRAM
+		},
+		{
+			amount: '.75oz',
+			ingredient: Ingredients.Citrus.LIME
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Syrups.HONEY_SYRUP
 		},
 		{
 			amount: '1 dash',

--- a/src/lib/data/cocktails/wray-and-ting.ts
+++ b/src/lib/data/cocktails/wray-and-ting.ts
@@ -7,7 +7,7 @@ import { Ice } from '$lib/enums/ice';
 
 const WRAY_AND_TING: Cocktail = {
 	title: 'Wray and Ting',
-	description: 'Overproof jamaican rum, grapefruit soda.',
+	description: 'Overproof jamaican rum, grapefruit, rich simple, soda water, salt.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/wray-and-ting.png',
 	thumbnailImagePath:
@@ -23,8 +23,20 @@ const WRAY_AND_TING: Cocktail = {
 			ingredient: Ingredients.BaseSpirits.WRAY_AND_NEPHEW
 		},
 		{
-			amount: '4oz',
-			ingredient: Ingredients.Mixers.GRAPEFRUIT_SODA
+			amount: '1oz',
+			ingredient: Ingredients.Citrus.GRAPEFRUIT
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Syrups.RICH_SIMPLE_SYRUP
+		},
+		{
+			amount: '2.5oz',
+			ingredient: Ingredients.Mixers.SODA_WATER
+		},
+		{
+			label: 'Pinch of salt',
+			ingredient: Ingredients.Other.SALT
 		}
 	],
 	tags: [

--- a/src/lib/data/ingredients/beer-and-wine.ts
+++ b/src/lib/data/ingredients/beer-and-wine.ts
@@ -5,7 +5,7 @@ import type { IngredientCategory, Ingredient } from '$lib/types/ingredients';
 const BITBURGER_PILS: Ingredient = {
 	title: 'Bitburger Pils',
 	slug: 'bitburger-pils',
-	costPerOz: 10 / (12 * 6)
+	costPerOz: 19 / (11.2 * 12)
 };
 const GUINNESS_DRAUGHT: Ingredient = {
 	title: 'Guinness Draught',
@@ -20,7 +20,7 @@ const MILLER_HIGH_LIFE: Ingredient = {
 const TECATE_MEXICAN_LAGER: Ingredient = {
 	title: 'Tecate Mexican Lager',
 	slug: 'tecate-mexican-lager',
-	costPerOz: 16 / 12 / 18
+	costPerOz: 16 / (12 * 18)
 };
 
 // Wine

--- a/src/lib/data/ingredients/mixers.ts
+++ b/src/lib/data/ingredients/mixers.ts
@@ -17,11 +17,6 @@ const GINGER_BEER: Ingredient = {
 	slug: 'ginger-beer',
 	costPerOz: 1 / 6
 };
-const GRAPEFRUIT_SODA: Ingredient = {
-	title: 'Grapefruit Soda',
-	slug: 'grapefruit-soda',
-	costPerOz: 1 / 8
-};
 const SANPELLEGRINO_LIMONATA: Ingredient = {
 	title: 'Sanpellegrino Limonata',
 	slug: 'sanpellegrino-limonata',
@@ -55,7 +50,6 @@ export const MIXERS: IngredientCategory = {
 				APPLE_CIDER,
 				COCA_COLA,
 				GINGER_BEER,
-				GRAPEFRUIT_SODA,
 				SANPELLEGRINO_LIMONATA,
 				SODA_WATER,
 				SPICED_TEA,
@@ -69,7 +63,6 @@ export const INGREDIENTS = {
 	APPLE_CIDER,
 	COCA_COLA,
 	GINGER_BEER,
-	GRAPEFRUIT_SODA,
 	SANPELLEGRINO_LIMONATA,
 	SODA_WATER,
 	SPICED_TEA,

--- a/src/lib/data/tiki-menu.ts
+++ b/src/lib/data/tiki-menu.ts
@@ -9,7 +9,7 @@ import JUNGLE_BIRD from '$lib/data/cocktails/jungle-bird';
 import MAI_TAI from '$lib/data/cocktails/mai-tai';
 import NORWEIGAN_PARALYSIS from '$lib/data/cocktails/norwegian-paralysis';
 import PAINKILLER from '$lib/data/cocktails/painkiller';
-import PORT_LIGHT from '$lib/data/cocktails/port-light';
+import DESERT_DREAMS from '$lib/data/cocktails/desert-dreams';
 import SATURN from '$lib/data/cocktails/saturn';
 import SINGAPORE_SLING from '$lib/data/cocktails/singapore-sling';
 import THREE_DOTS_AND_A_DASH from '$lib/data/cocktails/three-dots-and-a-dash';
@@ -48,6 +48,6 @@ export const categories: Category[] = [
 			tertiary: '#fef3c7',
 			variationText: '#9a3412'
 		},
-		cocktails: [SINGAPORE_SLING, SATURN, GILDA, IRON_RANGER, PORT_LIGHT, NORWEIGAN_PARALYSIS]
+		cocktails: [SINGAPORE_SLING, SATURN, GILDA, IRON_RANGER, DESERT_DREAMS, NORWEIGAN_PARALYSIS]
 	}
 ];

--- a/src/routes/cocktails/[slug]/+page.svelte
+++ b/src/routes/cocktails/[slug]/+page.svelte
@@ -72,15 +72,17 @@
 			<div class="p-8">
 				<!-- Header -->
 				<header class="mb-8">
-					<div class="flex items-center gap-3 mb-2">
-						<h1 class="text-4xl font-bold text-gray-800">{cocktail.title}</h1>
-						{#if cocktail.tags?.includes(Tags.Origin.ORIGINAL)}
-							<div
-								class="bg-amber-100 text-amber-700 border border-amber-300 text-xs font-semibold px-2 py-0.5 rounded-full"
-							>
-								★ Original
-							</div>
-						{/if}
+					<div class="flex items-start justify-between gap-3 mb-2">
+						<div class="flex flex-wrap items-center gap-3">
+							<h1 class="text-4xl font-bold text-gray-800">{cocktail.title}</h1>
+							{#if cocktail.tags?.includes(Tags.Origin.ORIGINAL)}
+								<div
+									class="bg-amber-100 text-amber-700 border border-amber-300 text-xs font-semibold px-2 py-0.5 rounded-full whitespace-nowrap"
+								>
+									★ Original
+								</div>
+							{/if}
+						</div>
 						<CopyLinkButton
 							url={typeof window !== 'undefined' ? window.location.href : ''}
 							ariaLabel="Copy link to {cocktail.title}"


### PR DESCRIPTION
## Summary
- Add three new cocktails: Conference, Desert Dreams, and Shark's Tooth
- Refine existing recipes (Paloma, Three Dots and a Dash, Wray and Ting) and ingredient data
- Improve cocktail detail page header to handle long titles alongside the Original badge

## Test plan
- [ ] Verify new cocktails appear in `/cocktails` and render correctly on their detail pages
- [ ] Check header layout on cocktail detail pages for both short and long titles (with and without Original badge)
- [ ] Confirm refined recipes display updated ingredients/notes
- [ ] Run `npm run lint`, `npm run check`, and `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)