### PR TITLE
feat: add spirit dilution calculator, House Dark Berry Crème, and cocktail refinements

### DIFF
--- a/src/lib/data/all-recipes.ts
+++ b/src/lib/data/all-recipes.ts
@@ -21,6 +21,7 @@ import CITRON_VODKA from '$lib/data/recipes/citron-vodka';
 import CREME_DE_CACAO from '$lib/data/recipes/creme-de-cacao';
 import DRY_CURACAO from '$lib/data/recipes/dry-curacao';
 import FALERNUM from '$lib/data/recipes/falernum';
+import HOUSE_DARK_BERRY_CREME from '$lib/data/recipes/house-dark-berry-creme';
 import JALAPENO_TEQUILA from '$lib/data/recipes/jalapeno-tequila';
 import LIMONCELLO from '$lib/data/recipes/limoncello';
 import PEPPERMINT_VODKA from '$lib/data/recipes/peppermint-vodka';
@@ -51,6 +52,7 @@ export const infusions: Recipe[] = [
 	CREME_DE_CACAO,
 	DRY_CURACAO,
 	FALERNUM,
+	HOUSE_DARK_BERRY_CREME,
 	JALAPENO_TEQUILA,
 	LIMONCELLO,
 	PEPPERMINT_VODKA,

--- a/src/lib/data/cocktails/espresso-martini.ts
+++ b/src/lib/data/cocktails/espresso-martini.ts
@@ -40,7 +40,17 @@ const ESPRESSO_MARTINI: Cocktail = {
 	],
 	variations: [
 		{
-			name: 'Hazelnut',
+			name: 'Tequila',
+			ingredients: [
+				{
+					label: 'Swap Cognac with Cimarron Reposado Tequila.',
+					ingredient: Ingredients.BaseSpirits.CIMARRON_REPOSADO
+				}
+			],
+			images: []
+		},
+		{
+			name: '+Hazelnut',
 			ingredients: [
 				{
 					label: 'Swap .5oz of Cognac with Frangelico.',
@@ -50,7 +60,7 @@ const ESPRESSO_MARTINI: Cocktail = {
 			images: []
 		},
 		{
-			name: 'Peppermint',
+			name: '+Peppermint',
 			ingredients: [
 				{
 					label: 'Swap .5oz of Cognac with peppermint infused vodka.',
@@ -60,24 +70,10 @@ const ESPRESSO_MARTINI: Cocktail = {
 			images: []
 		},
 		{
-			name: 'Chocolate',
+			name: '+Chocolate',
 			ingredients: [
 				{
 					label: 'Swap .5oz of Cognac with Crème de Cacao.',
-					ingredient: Ingredients.Liqueurs.CREME_DE_CACAO
-				}
-			],
-			images: []
-		},
-		{
-			name: '"Nutella"',
-			ingredients: [
-				{
-					label: 'Swap .25oz of Cognac with Frangelico.',
-					ingredient: Ingredients.Liqueurs.FRANGELICO
-				},
-				{
-					label: 'Swap .25oz of Cognac with Crème de Cacao.',
 					ingredient: Ingredients.Liqueurs.CREME_DE_CACAO
 				}
 			],

--- a/src/lib/data/cocktails/planters-punch.ts
+++ b/src/lib/data/cocktails/planters-punch.ts
@@ -45,7 +45,8 @@ const PLANTERS_PUNCH: Cocktail = {
 		Tags.BaseAlcohol.RUM,
 		Tags.FlavorProfile.CITRUS,
 		Tags.Technique.FLASH_BLENDED,
-		Tags.ServedIn.HIGHBALL_GLASS
+		Tags.ServedIn.HIGHBALL_GLASS,
+		Tags.PrepTime.SIMPLE_PREP
 	]
 };
 

--- a/src/lib/data/ingredients/liqueurs.ts
+++ b/src/lib/data/ingredients/liqueurs.ts
@@ -5,6 +5,7 @@ import LIMONCELLO_RECIPE from '$lib/data/recipes/limoncello';
 import FALERNUM_RECIPE from '$lib/data/recipes/falernum';
 import PERSIAN_SPICE_LIQUEUR_RECIPE from '$lib/data/recipes/persian-spice-liqueur';
 import DRY_CURACAO_RECIPE from '$lib/data/recipes/dry-curacao';
+import HOUSE_DARK_BERRY_CREME_RECIPE from '$lib/data/recipes/house-dark-berry-creme';
 
 // Amaro
 const AMARO_LUCANO: Ingredient = {
@@ -93,6 +94,12 @@ const MARASCHINO_LIQUEUER: Ingredient = {
 	slug: 'maraschino-liqueuer',
 	costPerOz: 40 / 25
 };
+const HOUSE_DARK_BERRY_CREME: Ingredient = {
+	title: 'House Dark Berry Crème',
+	slug: 'house-dark-berry-creme',
+	recipe: HOUSE_DARK_BERRY_CREME_RECIPE,
+	costPerOz: 15 / 21.667
+};
 
 // Nut & Spice
 const ALLSPICE_DRAM: Ingredient = {
@@ -178,6 +185,7 @@ export const LIQUEURS: IngredientCategory = {
 				DRY_CURACAO,
 				COINTREAU,
 				CHERRY_HEERING,
+				HOUSE_DARK_BERRY_CREME,
 				MARASCHINO_LIQUEUER
 			]
 		},
@@ -218,6 +226,7 @@ export const INGREDIENTS = {
 	DRY_CURACAO,
 	COINTREAU,
 	CHERRY_HEERING,
+	HOUSE_DARK_BERRY_CREME,
 	MARASCHINO_LIQUEUER,
 
 	// Nut & Spice

--- a/src/lib/data/recipes/house-dark-berry-creme.ts
+++ b/src/lib/data/recipes/house-dark-berry-creme.ts
@@ -1,0 +1,22 @@
+import type { Recipe } from '$lib/types/recipes';
+
+const HOUSE_DARK_BERRY_CREME: Recipe = {
+	name: 'House Dark Berry Crème',
+	slug: 'house-dark-berry-creme',
+	description: 'A rich berry liqueur infused with vodka, lemon peel, and Ceylon black tea.',
+	ingredients: [
+		'300g blueberries',
+		'200g blackberries',
+		'50g raspberries',
+		'400mL vodka (40-50% ABV)',
+		'225g granulated sugar',
+		'2 strips lemon peel (no pith)',
+		'0.3g Ceylon black tea leaves'
+	],
+	instructions:
+		'Lightly crush all fruit in a jar. Add vodka, lemon peel, and tea leaves. Seal and shake. Let macerate for 2 weeks, shaking occasionally. Strain through fine mesh, then strain again through cheesecloth or a coffee filter. Stir in sugar until fully dissolved. Bottle and rest for 1-2 weeks before using.',
+	notes:
+		'Store sealed in the refrigerator or a cool, dark place. Best after 2-4 weeks; keeps well for up to 1 year.'
+};
+
+export default HOUSE_DARK_BERRY_CREME;

--- a/src/lib/utils/spirit-dilution.ts
+++ b/src/lib/utils/spirit-dilution.ts
@@ -1,0 +1,50 @@
+export const ML_PER_FL_OZ = 29.575;
+
+const DENSITY_TABLE: ReadonlyArray<readonly [number, number]> = [
+	[40, 0.948],
+	[70, 0.867],
+	[95, 0.811],
+	[100, 0.789]
+];
+
+export function densityForABV(abv: number): number {
+	if (abv <= DENSITY_TABLE[0][0]) return DENSITY_TABLE[0][1];
+	if (abv >= DENSITY_TABLE[DENSITY_TABLE.length - 1][0])
+		return DENSITY_TABLE[DENSITY_TABLE.length - 1][1];
+	for (let i = 0; i < DENSITY_TABLE.length - 1; i++) {
+		const [a1, d1] = DENSITY_TABLE[i];
+		const [a2, d2] = DENSITY_TABLE[i + 1];
+		if (abv >= a1 && abv <= a2) {
+			return d1 + ((abv - a1) / (a2 - a1)) * (d2 - d1);
+		}
+	}
+	return DENSITY_TABLE[DENSITY_TABLE.length - 1][1];
+}
+
+export type Unit = 'mL' | 'fl oz';
+
+export interface DilutionResult {
+	sourceVolume: number;
+	waterVolume: number;
+	sourceWeight: number;
+	waterWeight: number;
+}
+
+export function calculateDilution(args: {
+	targetABV: number;
+	sourceABV: number;
+	finalVolume: number;
+	unit: Unit;
+}): DilutionResult {
+	const finalMl = args.unit === 'fl oz' ? args.finalVolume * ML_PER_FL_OZ : args.finalVolume;
+	const sourceMl = finalMl * (args.targetABV / args.sourceABV);
+	const waterMl = finalMl - sourceMl;
+	const density = densityForABV(args.sourceABV);
+	const toUnit = (ml: number) => (args.unit === 'fl oz' ? ml / ML_PER_FL_OZ : ml);
+	return {
+		sourceVolume: toUnit(sourceMl),
+		waterVolume: toUnit(waterMl),
+		sourceWeight: sourceMl * density,
+		waterWeight: waterMl
+	};
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -134,6 +134,11 @@
 			<MenuLink href="/parties" label="Cocktail Parties" variant="secondary" />
 			<MenuLink href="/bartenders" label="Bartenders" variant="secondary" />
 			<MenuLink href="/recipes" label="Recipes" variant="secondary" />
+			<MenuLink
+				href="/spirit-dilution-calculator"
+				label="Dilution Calculator"
+				variant="secondary"
+			/>
 		</nav>
 	</section>
 

--- a/src/routes/spirit-dilution-calculator/+page.svelte
+++ b/src/routes/spirit-dilution-calculator/+page.svelte
@@ -1,0 +1,307 @@
+<script lang="ts">
+	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
+	import ScrollToTop from '$lib/components/ScrollToTop.svelte';
+	import { fade, fly } from 'svelte/transition';
+	import { calculateDilution, type Unit } from '$lib/utils/spirit-dilution';
+
+	let targetABV = 40;
+	let sourceABV = 95;
+	let finalVolume = 400;
+	let unit: Unit = 'mL';
+
+	$: valid =
+		Number.isFinite(targetABV) &&
+		Number.isFinite(sourceABV) &&
+		Number.isFinite(finalVolume) &&
+		targetABV > 0 &&
+		sourceABV > 0 &&
+		finalVolume > 0 &&
+		targetABV < sourceABV &&
+		sourceABV <= 100 &&
+		targetABV <= 100;
+
+	$: result = valid ? calculateDilution({ targetABV, sourceABV, finalVolume, unit }) : null;
+
+	function fmt(n: number): string {
+		return n.toFixed(2);
+	}
+
+	function validationMessage(): string {
+		if (!Number.isFinite(targetABV) || !Number.isFinite(sourceABV) || !Number.isFinite(finalVolume))
+			return 'Enter values for all three fields.';
+		if (finalVolume <= 0) return 'Final volume must be greater than zero.';
+		if (targetABV <= 0 || sourceABV <= 0) return 'ABV values must be greater than zero.';
+		if (targetABV > 100 || sourceABV > 100) return 'ABV values cannot exceed 100%.';
+		if (targetABV >= sourceABV) return 'Target ABV must be lower than source ABV.';
+		return '';
+	}
+
+	$: hint = valid ? '' : validationMessage();
+</script>
+
+<svelte:head>
+	<title>Spirit Dilution Calculator - The Krauss Haus</title>
+	<meta
+		name="description"
+		content="Convert high-proof alcohol into your desired ABV with precise water ratios."
+	/>
+	<meta property="og:image" content="https://thekrausshaus.com/images/open-graph/og-root.jpg" />
+</svelte:head>
+
+<main
+	class="min-h-screen p-6 bg-[#f8f9fa] overflow-y-auto"
+	in:fly={{ y: 20, duration: 400, delay: 200 }}
+	out:fade={{ duration: 200 }}
+>
+	<div class="max-w-3xl mx-auto pb-8">
+		<Breadcrumbs />
+
+		<header class="text-center mb-12" in:fly={{ y: 20, duration: 400, delay: 400 }}>
+			<h1 class="text-4xl font-bold text-gray-800 mb-4">Spirit Dilution Calculator</h1>
+			<p class="text-gray-600">
+				Convert high-proof alcohol into your desired ABV with precise water ratios.
+			</p>
+		</header>
+
+		<!-- Inputs -->
+		<section class="mb-8" in:fly={{ y: 20, duration: 400, delay: 600 }}>
+			<div class="bg-white rounded-lg shadow-sm overflow-hidden">
+				<div class="bg-gradient-to-r from-blue-50 to-indigo-50 px-8 py-6 border-b border-blue-100">
+					<div class="flex items-center gap-3">
+						<div class="w-8 h-8 bg-blue-200 rounded-full flex items-center justify-center">
+							<svg
+								class="w-5 h-5 text-blue-700"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M12 4v16m8-8H4"
+								/>
+							</svg>
+						</div>
+						<h2 class="text-2xl font-bold text-gray-800">Inputs</h2>
+					</div>
+				</div>
+
+				<div class="p-8 grid grid-cols-1 sm:grid-cols-2 gap-6">
+					<div>
+						<label for="targetABV" class="block text-sm font-medium text-gray-700 mb-2">
+							Target ABV
+						</label>
+						<div class="relative">
+							<input
+								id="targetABV"
+								type="number"
+								min="0"
+								max="100"
+								step="0.1"
+								bind:value={targetABV}
+								class="w-full px-4 py-2 pr-10 rounded-lg border border-gray-200 focus:outline-none focus:border-blue-400"
+							/>
+							<span
+								class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 text-sm pointer-events-none"
+								>%</span
+							>
+						</div>
+					</div>
+
+					<div>
+						<label for="sourceABV" class="block text-sm font-medium text-gray-700 mb-2">
+							Source ABV
+						</label>
+						<div class="relative">
+							<input
+								id="sourceABV"
+								type="number"
+								min="0"
+								max="100"
+								step="0.1"
+								bind:value={sourceABV}
+								class="w-full px-4 py-2 pr-10 rounded-lg border border-gray-200 focus:outline-none focus:border-blue-400"
+							/>
+							<span
+								class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 text-sm pointer-events-none"
+								>%</span
+							>
+						</div>
+					</div>
+
+					<div class="sm:col-span-2">
+						<label for="finalVolume" class="block text-sm font-medium text-gray-700 mb-2">
+							Final Volume
+						</label>
+						<div class="flex gap-2">
+							<input
+								id="finalVolume"
+								type="number"
+								min="0"
+								step="any"
+								bind:value={finalVolume}
+								class="flex-1 px-4 py-2 rounded-lg border border-gray-200 focus:outline-none focus:border-blue-400"
+							/>
+							<div
+								class="inline-flex rounded-lg border border-gray-200 overflow-hidden"
+								role="group"
+								aria-label="Unit"
+							>
+								<button
+									type="button"
+									on:click={() => (unit = 'mL')}
+									class="px-4 py-2 text-sm transition-colors {unit === 'mL'
+										? 'bg-gray-800 text-white'
+										: 'bg-white text-gray-700 hover:bg-gray-50'}"
+									aria-pressed={unit === 'mL'}
+								>
+									mL
+								</button>
+								<button
+									type="button"
+									on:click={() => (unit = 'fl oz')}
+									class="px-4 py-2 text-sm transition-colors border-l border-gray-200 {unit ===
+									'fl oz'
+										? 'bg-gray-800 text-white'
+										: 'bg-white text-gray-700 hover:bg-gray-50'}"
+									aria-pressed={unit === 'fl oz'}
+								>
+									fl oz
+								</button>
+							</div>
+						</div>
+					</div>
+
+					{#if hint}
+						<div class="sm:col-span-2 text-sm text-amber-700">
+							{hint}
+						</div>
+					{/if}
+				</div>
+			</div>
+		</section>
+
+		<!-- Volume -->
+		<section class="mb-8" in:fly={{ y: 20, duration: 400, delay: 800 }}>
+			<div class="bg-white rounded-lg shadow-sm overflow-hidden">
+				<div
+					class="bg-gradient-to-r from-amber-50 to-yellow-50 px-8 py-6 border-b border-amber-100"
+				>
+					<div class="flex items-center gap-3">
+						<div class="w-8 h-8 bg-amber-200 rounded-full flex items-center justify-center">
+							<svg
+								class="w-5 h-5 text-amber-700"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M5 3h14l-1 4H6L5 3zm1 4h12l-1 13a1 1 0 01-1 1H8a1 1 0 01-1-1L6 7z"
+								/>
+							</svg>
+						</div>
+						<h2 class="text-2xl font-bold text-gray-800">Volume</h2>
+					</div>
+				</div>
+
+				<div class="p-8">
+					{#if result}
+						<dl class="divide-y divide-gray-100">
+							<div class="flex items-baseline justify-between py-4">
+								<dt class="text-gray-600">Source spirit</dt>
+								<dd class="text-2xl font-semibold text-gray-800">
+									{fmt(result.sourceVolume)}
+									<span class="text-base font-normal text-gray-500 ml-1">{unit}</span>
+								</dd>
+							</div>
+							<div class="flex items-baseline justify-between py-4">
+								<dt class="text-gray-600">
+									<span class="inline-block w-4 text-gray-400 font-medium">+</span>
+									Water
+								</dt>
+								<dd class="text-2xl font-semibold text-gray-800">
+									{fmt(result.waterVolume)}
+									<span class="text-base font-normal text-gray-500 ml-1">{unit}</span>
+								</dd>
+							</div>
+							<div class="flex items-baseline justify-between py-4 border-t-2 border-gray-200">
+								<dt class="text-gray-700 font-medium">
+									<span class="inline-block w-4 text-gray-400 font-medium">=</span>
+									Final volume
+								</dt>
+								<dd class="text-2xl font-semibold text-gray-800">
+									{fmt(result.sourceVolume + result.waterVolume)}
+									<span class="text-base font-normal text-gray-500 ml-1">{unit}</span>
+								</dd>
+							</div>
+						</dl>
+					{:else}
+						<p class="text-gray-500 text-center py-6">Enter values to see the breakdown.</p>
+					{/if}
+				</div>
+			</div>
+		</section>
+
+		<!-- Weight -->
+		<section class="mb-8" in:fly={{ y: 20, duration: 400, delay: 1000 }}>
+			<div class="bg-white rounded-lg shadow-sm overflow-hidden">
+				<div
+					class="bg-gradient-to-r from-emerald-50 to-teal-50 px-8 py-6 border-b border-emerald-100"
+				>
+					<div class="flex items-center gap-3">
+						<div class="w-8 h-8 bg-emerald-200 rounded-full flex items-center justify-center">
+							<svg
+								class="w-5 h-5 text-emerald-700"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M3 6l3 12h12l3-12M3 6l9-3 9 3M3 6h18M9 21h6"
+								/>
+							</svg>
+						</div>
+						<h2 class="text-2xl font-bold text-gray-800">Weight</h2>
+					</div>
+				</div>
+
+				<div class="p-8">
+					{#if result}
+						<dl class="divide-y divide-gray-100">
+							<div class="flex items-baseline justify-between py-4">
+								<dt class="text-gray-600">Source spirit</dt>
+								<dd class="text-2xl font-semibold text-gray-800">
+									{fmt(result.sourceWeight)}
+									<span class="text-base font-normal text-gray-500 ml-1">g</span>
+								</dd>
+							</div>
+							<div class="flex items-baseline justify-between py-4">
+								<dt class="text-gray-600">Water</dt>
+								<dd class="text-2xl font-semibold text-gray-800">
+									{fmt(result.waterWeight)}
+									<span class="text-base font-normal text-gray-500 ml-1">g</span>
+								</dd>
+							</div>
+						</dl>
+					{:else}
+						<p class="text-gray-500 text-center py-6">Enter values to see the breakdown.</p>
+					{/if}
+				</div>
+			</div>
+		</section>
+
+		<p class="text-sm text-gray-500 text-center px-4">
+			Final mixed volume may vary slightly because alcohol and water contract when combined. Weights
+			are estimates from a density table.
+		</p>
+	</div>
+
+	<ScrollToTop />
+</main>


### PR DESCRIPTION
## Summary
- Add a new spirit dilution calculator page at `/spirit-dilution-calculator` with helper utilities in `src/lib/utils/spirit-dilution.ts`, plus a homepage entry
- Add House Dark Berry Crème recipe and refresh Espresso Martini variations
- Refine Planter's Punch

## Test plan
- [ ] `npm run lint`
- [ ] `npm run check`
- [ ] `npm run test`
- [ ] `npm run dev` — verify `/spirit-dilution-calculator` renders and computes correctly
- [ ] Visit new cocktails (Conference, Desert Dreams, Shark's Tooth) and confirm rendering
- [ ] Confirm Espresso Martini variations and House Dark Berry Crème recipe render
- [ ] Verify long cocktail titles display correctly alongside the Original badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)