### PR TITLE
refactor(cocktails): update Navy Grog recipe and shuffle path/menu cocktails

### DIFF
--- a/src/lib/data/cocktail-paths/fisherman.ts
+++ b/src/lib/data/cocktail-paths/fisherman.ts
@@ -1,8 +1,8 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
 import CAIPIRINHA from '../cocktails/caipirinha';
 import LOST_LAKE from '../cocktails/lost-lake';
-import MICHELADA from '../cocktails/michelada';
 import SEA_LEGS from '../cocktails/sea-legs';
+import SHARKS_TOOTH from '../cocktails/sharks-tooth';
 import SPAGHETT from '../cocktails/spaghett';
 
 export const FISHERMAN: CocktailPath = {
@@ -13,5 +13,5 @@ export const FISHERMAN: CocktailPath = {
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/fisherman.jpeg',
 	description:
 		'Kick off your shoes and unwind by the water. This path starts with muddled citrus simplicity, drifts into light beer-and-bitter refreshment, picks up fruity tropical notes, then cools down with a savory, spiced sipper before finishing with a true sea-worn cocktail—smoky, bold flavors that echo the ocean itself.',
-	cocktails: [CAIPIRINHA, SPAGHETT, LOST_LAKE, MICHELADA, SEA_LEGS]
+	cocktails: [CAIPIRINHA, SPAGHETT, SHARKS_TOOTH, LOST_LAKE, SEA_LEGS]
 };

--- a/src/lib/data/cocktail-paths/shaman.ts
+++ b/src/lib/data/cocktail-paths/shaman.ts
@@ -1,8 +1,8 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
 import DESERT_DREAMS from '../cocktails/desert-dreams';
-import DIVISION_BELL from '../cocktails/division-bell';
-import GILDA from '../cocktails/gilda';
 import MARGARITA from '../cocktails/margarita';
+import MICHELADA from '../cocktails/michelada';
+import OAXACA_OLD_FASHIONED from '../cocktails/oaxaca-old-fashioned';
 import TIA_MIA from '../cocktails/tia-mia';
 
 export const SHAMAN: CocktailPath = {
@@ -13,5 +13,5 @@ export const SHAMAN: CocktailPath = {
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/shaman.jpeg',
 	description:
 		'Follow the agave from field to flame. This path opens with the most iconic citrus cocktail on earth, then dreams into passion fruit and a whisper of mezcal, drifts through tropical pineapple warmth, and as mezcal enters alongside rum, the smoke builds until by the final pour it stands alone—balanced, bitter, and modern.',
-	cocktails: [MARGARITA, DESERT_DREAMS, GILDA, TIA_MIA, DIVISION_BELL]
+	cocktails: [MARGARITA, DESERT_DREAMS, MICHELADA, TIA_MIA, OAXACA_OLD_FASHIONED]
 };

--- a/src/lib/data/cocktail-paths/warrior.ts
+++ b/src/lib/data/cocktail-paths/warrior.ts
@@ -1,6 +1,6 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
 import MINT_JULEP from '../cocktails/mint-julep';
-import OAXACA_OLD_FASHIONED from '../cocktails/oaxaca-old-fashioned';
+import NAVY_GROG from '../cocktails/navy-grog';
 import OLD_FASHIONED from '../cocktails/old-fashioned';
 import PENICILLIN from '../cocktails/penicillin';
 import SAZERAC from '../cocktails/sazerac';
@@ -13,5 +13,5 @@ export const WARRIOR: CocktailPath = {
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/warrior.jpeg',
 	description:
 		'The spirit leads and everything else falls in line. This path starts with sweetened structure and familiar warmth, then pushes through smoky heat and honeyed spice before arriving at raw, unadorned intensity. Each step strips away a little more, demanding respect for the base spirit.',
-	cocktails: [OLD_FASHIONED, MINT_JULEP, OAXACA_OLD_FASHIONED, PENICILLIN, SAZERAC]
+	cocktails: [OLD_FASHIONED, NAVY_GROG, MINT_JULEP, PENICILLIN, SAZERAC]
 };

--- a/src/lib/data/cocktails/navy-grog.ts
+++ b/src/lib/data/cocktails/navy-grog.ts
@@ -4,41 +4,37 @@ import type { Cocktail } from '$lib/types/cocktails';
 import { Ingredients } from '../all-ingredients';
 import { Tags } from '../all-tags';
 import { Ice } from '$lib/enums/ice';
-import DONN_THE_BEACHCOMBER from '$lib/data/bartenders/donn-beach';
+import DONN_BEACH from '$lib/data/bartenders/donn-beach';
 
 const NAVY_GROG: Cocktail = {
 	title: 'Navy Grog',
 	description:
-		'Jamaican rum, demerara rum, blended light rum, honey syrup, lime, grapefruit, soda water.',
+		'Jamaican rum, demerara rum, honey syrup, lime, grapefruit, angostura bitters, soda water.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/navy-grog.png',
 	thumbnailImagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/navy-grog.png',
 	slug: 'navy-grog',
-	createdBy: DONN_THE_BEACHCOMBER,
+	createdBy: DONN_BEACH,
 	method: CocktailMethod.Shaken,
 	servedIn: ServedIn.DoubleRocksGlass,
-	ice: Ice.LargeCube,
-	hasStraw: false,
+	ice: Ice.Crushed,
+	hasStraw: true,
 	ingredients: [
 		{
 			amount: '.75oz',
 			ingredient: Ingredients.BaseSpirits.CORUBA
 		},
 		{
-			amount: '.75oz',
-			ingredient: Ingredients.BaseSpirits.APPLETON_ESTATE_SIGNATURE
-		},
-		{
-			amount: '.75oz',
+			amount: '1oz',
 			ingredient: Ingredients.BaseSpirits.HAMILTON_86
 		},
 		{
-			amount: '.75oz',
-			ingredient: Ingredients.BaseSpirits.PROBITAS
+			amount: '.5oz',
+			ingredient: Ingredients.BaseSpirits.SMITH_AND_CROSS
 		},
 		{
-			amount: '1oz',
+			amount: '.75oz',
 			ingredient: Ingredients.Syrups.HONEY_SYRUP
 		},
 		{
@@ -46,8 +42,12 @@ const NAVY_GROG: Cocktail = {
 			ingredient: Ingredients.Citrus.LIME
 		},
 		{
-			amount: '.75oz',
+			amount: '1oz',
 			ingredient: Ingredients.Citrus.GRAPEFRUIT
+		},
+		{
+			amount: '1 dash',
+			ingredient: Ingredients.Bitters.ANGOSTURA
 		},
 		{
 			amount: '1oz',
@@ -59,7 +59,7 @@ const NAVY_GROG: Cocktail = {
 		}
 	],
 	notes:
-		'One of the only classic tiki cocktails not served over crushed ice. Shake all ingredients besides soda water with ice. Strain into a glass over ice block. Top with soda water, serve with a straw, and garnish with mint sprig.',
+		'Shake everything except soda with ice for 10-12 seconds. Strain over crushed or pebble ice in a double rocks glass or tiki mug. Top with soda and give a quick swizzle. Garnish with a mint sprig and optional spent lime shell.',
 	tags: [
 		Tags.Style.TIKI,
 		Tags.Origin.CLASSIC,

--- a/src/lib/data/tiki-menu.ts
+++ b/src/lib/data/tiki-menu.ts
@@ -15,7 +15,7 @@ import SINGAPORE_SLING from '$lib/data/cocktails/singapore-sling';
 import THREE_DOTS_AND_A_DASH from '$lib/data/cocktails/three-dots-and-a-dash';
 import ZOMBIE from '$lib/data/cocktails/zombie';
 import LOST_LAKE from '$lib/data/cocktails/lost-lake';
-import RUM_BARREL from '$lib/data/cocktails/rum-barrel';
+import NAVY_GROG from '$lib/data/cocktails/navy-grog';
 import DONGA_PUNCH from '$lib/data/cocktails/donga-punch';
 import DAIQUIRI from './cocktails/daiquiri';
 
@@ -38,7 +38,7 @@ export const categories: Category[] = [
 			tertiary: '#fdf2f8',
 			variationText: '#581c87'
 		},
-		cocktails: [LOST_LAKE, MAI_TAI, THREE_DOTS_AND_A_DASH, RUM_BARREL, COBRAS_FANG, ZOMBIE]
+		cocktails: [NAVY_GROG, LOST_LAKE, MAI_TAI, THREE_DOTS_AND_A_DASH, COBRAS_FANG, ZOMBIE]
 	},
 	{
 		title: 'Not Just Rum',


### PR DESCRIPTION
## Summary
- Reworked the Navy Grog recipe: switched to a Jamaican/demerara split (Coruba, Hamilton 86, Smith & Cross), adjusted measurements, added Angostura, swapped to crushed ice with a straw, and updated prep notes. Also fixed the bartender import to `DONN_BEACH`.
- Shuffled cocktails across the Fisherman, Shaman, and Warrior paths (e.g., Shark's Tooth into Fisherman, Michelada/Oaxaca Old Fashioned into Shaman, Navy Grog into Warrior).
- Replaced Rum Barrel with Navy Grog in the tiki menu's rum section.

## Test plan
- [ ] `npm run check` passes
- [ ] `npm run lint` passes
- [ ] Visually verify Navy Grog page renders new ingredients/notes
- [ ] Visually verify Fisherman, Shaman, and Warrior path pages show updated cocktail order
- [ ] Visually verify tiki menu rum section shows Navy Grog in place of Rum Barrel

🤖 Generated with [Claude Code](https://claude.com/claude-code)