### PR TITLE
Update cocktails and paths

### DIFF
--- a/src/lib/components/CocktailCard.svelte
+++ b/src/lib/components/CocktailCard.svelte
@@ -4,7 +4,6 @@
 	import { resolve } from '$app/paths';
 	import type { SectionColor } from '$lib/types/colors';
 	import type { CocktailVariant, Cocktail } from '$lib/types/cocktails';
-	import { methodColors } from '$lib/enums/methods';
 	import { Tags } from '$lib/data/all-tags';
 
 	import { getIngredientDisplayName, formatVariantIngredients } from '$lib/utils/ingredients';
@@ -211,19 +210,6 @@
 					>
 						{cocktail.title}
 					</a>
-					{#if cocktail.method}
-						<div class="mt-2">
-							<span class="text-xs text-gray-500 mb-2 font-light tracking-wide">Method:</span>
-							<span
-								class="px-3 py-1 text-xs font-medium rounded-full"
-								style="background-color: {methodColors[
-									cocktail.method as keyof typeof methodColors
-								]}; color: #374151;"
-							>
-								{cocktail.method.charAt(0).toUpperCase() + cocktail.method.slice(1)}
-							</span>
-						</div>
-					{/if}
 				</div>
 				<button
 					class="cursor-pointer text-gray-400 hover:text-gray-600 ml-4"

--- a/src/lib/data/all-cocktails.ts
+++ b/src/lib/data/all-cocktails.ts
@@ -11,6 +11,7 @@ import AZALEA from '$lib/data/cocktails/azalea';
 import BATANGA from '$lib/data/cocktails/batanga';
 import BITTER_GIUSEPPE from '$lib/data/cocktails/bitter-giuseppe';
 import BOULEVARDIER from '$lib/data/cocktails/boulevardier';
+import BRAMBLE from '$lib/data/cocktails/bramble';
 import BRANDY_ALEXANDER from '$lib/data/cocktails/brandy-alexander';
 import CAIPIRINHA from '$lib/data/cocktails/caipirinha';
 import CARAMEL_APPLE_SPICE from '$lib/data/cocktails/caramel-apple-spice';
@@ -32,6 +33,7 @@ import DESERT_DREAMS from '$lib/data/cocktails/desert-dreams';
 import DIVISION_BELL from '$lib/data/cocktails/division-bell';
 import DONGA_PUNCH from '$lib/data/cocktails/donga-punch';
 import DR_FUNK from '$lib/data/cocktails/dr-funk';
+import EL_DIABLO from '$lib/data/cocktails/el-diablo';
 import ESPRESSO_MARTINI from '$lib/data/cocktails/espresso-martini';
 import FERNET_CON_COCA from '$lib/data/cocktails/fernet-con-coca';
 import FOREST_SPIRIT from '$lib/data/cocktails/forest-spirit';
@@ -52,6 +54,7 @@ import JACK_ROSE from '$lib/data/cocktails/jack-rose';
 import JET_PILOT from '$lib/data/cocktails/jet-pilot';
 import JUNGLE_BIRD from '$lib/data/cocktails/jungle-bird';
 import KING_OF_KINGS from '$lib/data/cocktails/king-of-kings';
+import KIR_ROYALE from '$lib/data/cocktails/kir-royale';
 import LAST_WORD from '$lib/data/cocktails/last-word';
 import LEMON_DROP from '$lib/data/cocktails/lemon-drop';
 import LOGGY_CAB from '$lib/data/cocktails/loggy-cab';
@@ -86,6 +89,7 @@ import RADLER from '$lib/data/cocktails/radler';
 import RAMOS_GIN_FIZZ from '$lib/data/cocktails/ramos-gin-fizz';
 import RATTLE_SKULL from '$lib/data/cocktails/rattle-skull';
 import RUM_BARREL from '$lib/data/cocktails/rum-barrel';
+import RUSSIAN_SPRING_PUNCH from '$lib/data/cocktails/russian-spring-punch';
 import SALTY_DOG from '$lib/data/cocktails/salty-dog';
 import SANGRIA from '$lib/data/cocktails/sangria';
 import SATURN from '$lib/data/cocktails/saturn';
@@ -123,6 +127,7 @@ export const allCocktails: Cocktail[] = [
 	BATANGA,
 	BITTER_GIUSEPPE,
 	BOULEVARDIER,
+	BRAMBLE,
 	BRANDY_ALEXANDER,
 	CAIPIRINHA,
 	CARAMEL_APPLE_SPICE,
@@ -144,6 +149,7 @@ export const allCocktails: Cocktail[] = [
 	DIVISION_BELL,
 	DONGA_PUNCH,
 	DR_FUNK,
+	EL_DIABLO,
 	ESPRESSO_MARTINI,
 	FERNET_CON_COCA,
 	FRENCH_75,
@@ -164,6 +170,7 @@ export const allCocktails: Cocktail[] = [
 	JET_PILOT,
 	JUNGLE_BIRD,
 	KING_OF_KINGS,
+	KIR_ROYALE,
 	LAST_WORD,
 	LEMON_DROP,
 	LOGGY_CAB,
@@ -198,6 +205,7 @@ export const allCocktails: Cocktail[] = [
 	RAMOS_GIN_FIZZ,
 	RATTLE_SKULL,
 	RUM_BARREL,
+	RUSSIAN_SPRING_PUNCH,
 	SALTY_DOG,
 	SANGRIA,
 	SATURN,

--- a/src/lib/data/cocktail-paths/fisherman.ts
+++ b/src/lib/data/cocktail-paths/fisherman.ts
@@ -12,6 +12,6 @@ export const FISHERMAN: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/fisherman.jpeg',
 	description:
-		'Kick off your shoes and unwind by the water. This path starts with muddled citrus simplicity, drifts into light beer-and-bitter refreshment, picks up fruity tropical notes, then cools down with a savory, spiced sipper before finishing with a true sea-worn cocktail—smoky, bold flavors that echo the ocean itself.',
+		'Kick off your shoes and unwind by the water. This path starts with muddled cachaça simplicity, drifts into a low-ABV bitter-beer cooler, picks up tropical fruit and rum from a sidecar pour, deepens into a bittersweet tiki blend, and finishes with a smoky-briny scotch-and-mezcal sour that tastes of the sea itself.',
 	cocktails: [CAIPIRINHA, SPAGHETT, SHARKS_TOOTH, LOST_LAKE, SEA_LEGS]
 };

--- a/src/lib/data/cocktail-paths/shaman.ts
+++ b/src/lib/data/cocktail-paths/shaman.ts
@@ -12,6 +12,6 @@ export const SHAMAN: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/shaman.jpeg',
 	description:
-		'Follow the agave from field to flame. This path opens with the most iconic citrus cocktail on earth, then dreams into passion fruit and a whisper of mezcal, drifts through tropical pineapple warmth, and as mezcal enters alongside rum, the smoke builds until by the final pour it stands alone—balanced, bitter, and modern.',
+		'Follow the agave from field to flame. This path opens with the most iconic tequila citrus, then builds into chili-spiced tropical heat crowned with a float of mezcal, takes a savory beer-and-lime break, returns to mezcal in tiki disguise, and lands on a stirred, spirit-forward marriage of agave and smoke.',
 	cocktails: [MARGARITA, DESERT_DREAMS, MICHELADA, TIA_MIA, OAXACA_OLD_FASHIONED]
 };

--- a/src/lib/data/cocktail-paths/warrior.ts
+++ b/src/lib/data/cocktail-paths/warrior.ts
@@ -12,6 +12,6 @@ export const WARRIOR: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/warrior.jpeg',
 	description:
-		'The spirit leads and everything else falls in line. This path starts with sweetened structure and familiar warmth, then pushes through smoky heat and honeyed spice before arriving at raw, unadorned intensity. Each step strips away a little more, demanding respect for the base spirit.',
+		'The spirit leads and everything else falls in line. This path opens on a sweetened bourbon foundation, escalates into three-rum tropical strength, cools through crushed-ice mint and bourbon, warms again with smoke and honeyed ginger, and arrives at austere, anise-tinged power. Each step strips away a little more, demanding respect for the base spirit.',
 	cocktails: [OLD_FASHIONED, NAVY_GROG, MINT_JULEP, PENICILLIN, SAZERAC]
 };

--- a/src/lib/data/cocktails/bramble.ts
+++ b/src/lib/data/cocktails/bramble.ts
@@ -1,0 +1,55 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+import DICK_BRADSELL from '$lib/data/bartenders/dick-bradsell';
+
+const BRAMBLE: Cocktail = {
+	title: 'Bramble',
+	description: 'Gin, crème de baies noires, lemon, rich simple syrup.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/bramble.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/bramble.png',
+	slug: 'bramble',
+	createdBy: DICK_BRADSELL,
+	method: CocktailMethod.Shaken,
+	servedIn: ServedIn.DoubleRocksGlass,
+	ice: Ice.Crushed,
+	hasStraw: true,
+	ingredients: [
+		{
+			amount: '2oz',
+			ingredient: Ingredients.BaseSpirits.FORDS
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Liqueurs.HOUSE_DARK_BERRY_CREME
+		},
+		{
+			amount: '1oz',
+			ingredient: Ingredients.Citrus.LEMON
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.Syrups.RICH_SIMPLE_SYRUP
+		},
+		{
+			label: 'Garnish: Blackberry and lemon wheel',
+			ingredient: Ingredients.Citrus.LEMON_GARNISH
+		}
+	],
+	tags: [
+		Tags.BaseAlcohol.GIN,
+		Tags.FlavorProfile.CITRUS,
+		Tags.FlavorProfile.FRUITY,
+		Tags.Technique.SHAKEN,
+		Tags.Style.SOUR,
+		Tags.Origin.CLASSIC,
+		Tags.ServedIn.DOUBLE_ROCKS_GLASS
+	]
+};
+
+export default BRAMBLE;

--- a/src/lib/data/cocktails/desert-dreams.ts
+++ b/src/lib/data/cocktails/desert-dreams.ts
@@ -22,12 +22,8 @@ const DESERT_DREAMS: Cocktail = {
 	hasStraw: true,
 	ingredients: [
 		{
-			amount: '1.75oz',
+			amount: '2oz',
 			ingredient: Ingredients.BaseSpirits.CIMARRON_BLANCO
-		},
-		{
-			amount: '.25oz',
-			ingredient: Ingredients.BaseSpirits.DEL_MAGUY_VIDA
 		},
 		{
 			amount: '.5oz',
@@ -54,10 +50,15 @@ const DESERT_DREAMS: Cocktail = {
 			ingredient: Ingredients.Other.SALT
 		},
 		{
+			amount: '.25oz',
+			ingredient: Ingredients.BaseSpirits.DEL_MAGUY_VIDA
+		},
+		{
 			label: 'Garnish: Lime shell',
 			ingredient: Ingredients.Citrus.LIME_GARNISH
 		}
 	],
+	notes: 'Float .25oz of mezcal after pouring.',
 	tags: [
 		Tags.BaseAlcohol.TEQUILA,
 		Tags.BaseAlcohol.MEZCAL,

--- a/src/lib/data/cocktails/el-diablo.ts
+++ b/src/lib/data/cocktails/el-diablo.ts
@@ -1,0 +1,58 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+import TRADER_VIC from '$lib/data/bartenders/trader-vic';
+
+const EL_DIABLO: Cocktail = {
+	title: 'El Diablo',
+	description: 'Blanco tequila, crème de baies noires, lime, ginger beer.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/el-diablo.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/el-diablo.png',
+	slug: 'el-diablo',
+	createdBy: TRADER_VIC,
+	method: CocktailMethod.Built,
+	servedIn: ServedIn.HighballGlass,
+	ice: Ice.SmallCubes,
+	hasStraw: true,
+	ingredients: [
+		{
+			amount: '1.5oz',
+			ingredient: Ingredients.BaseSpirits.CIMARRON_BLANCO
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Liqueurs.HOUSE_DARK_BERRY_CREME
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Citrus.LIME
+		},
+		{
+			amount: '3oz',
+			ingredient: Ingredients.Mixers.GINGER_BEER
+		},
+		{
+			label: 'Garnish: Lime wedge',
+			ingredient: Ingredients.Citrus.LIME_GARNISH
+		}
+	],
+	tags: [
+		Tags.BaseAlcohol.TEQUILA,
+		Tags.FlavorProfile.CITRUS,
+		Tags.FlavorProfile.FRUITY,
+		Tags.FlavorProfile.SPICED,
+		Tags.FlavorProfile.BUBBLY,
+		Tags.Technique.BUILT,
+		Tags.AlcoholLevel.LOW,
+		Tags.Style.HIGHBALL,
+		Tags.Origin.CLASSIC,
+		Tags.ServedIn.HIGHBALL_GLASS
+	]
+};
+
+export default EL_DIABLO;

--- a/src/lib/data/cocktails/kir-royale.ts
+++ b/src/lib/data/cocktails/kir-royale.ts
@@ -1,0 +1,42 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+
+const KIR_ROYALE: Cocktail = {
+	title: 'Kir Royale',
+	description: 'Crème de baies noires, champagne.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/kir-royale.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/kir-royale.png',
+	slug: 'kir-royale',
+	method: CocktailMethod.Built,
+	servedIn: ServedIn.FluteGlass,
+	ice: Ice.None,
+	hasStraw: false,
+	ingredients: [
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Liqueurs.HOUSE_DARK_BERRY_CREME
+		},
+		{
+			amount: '4oz',
+			ingredient: Ingredients.BeerAndWine.CHAMPAGNE
+		}
+	],
+	tags: [
+		Tags.BaseAlcohol.WINE,
+		Tags.FlavorProfile.BUBBLY,
+		Tags.FlavorProfile.FRUITY,
+		Tags.Technique.BUILT,
+		Tags.Origin.CLASSIC,
+		Tags.AlcoholLevel.LOW,
+		Tags.ServedIn.FLUTE_GLASS,
+		Tags.PrepTime.SIMPLE_PREP
+	]
+};
+
+export default KIR_ROYALE;

--- a/src/lib/data/cocktails/navy-grog.ts
+++ b/src/lib/data/cocktails/navy-grog.ts
@@ -22,7 +22,7 @@ const NAVY_GROG: Cocktail = {
 	hasStraw: true,
 	ingredients: [
 		{
-			amount: '.75oz',
+			amount: '1oz',
 			ingredient: Ingredients.BaseSpirits.CORUBA
 		},
 		{
@@ -46,7 +46,7 @@ const NAVY_GROG: Cocktail = {
 			ingredient: Ingredients.Citrus.GRAPEFRUIT
 		},
 		{
-			amount: '1 dash',
+			amount: '2 dashes',
 			ingredient: Ingredients.Bitters.ANGOSTURA
 		},
 		{

--- a/src/lib/data/cocktails/penicillin.ts
+++ b/src/lib/data/cocktails/penicillin.ts
@@ -38,12 +38,12 @@ const PENICILLIN: Cocktail = {
 		},
 		'Garnish: Candied ginger'
 	],
+	notes: 'Float the single-malt scotch on top after pouring.',
 	tags: [
 		Tags.BaseAlcohol.WHISKEY,
 		Tags.FlavorProfile.CITRUS,
 		Tags.FlavorProfile.SPICED,
 		Tags.Technique.SHAKEN,
-
 		Tags.Style.SOUR,
 		Tags.Origin.MODERN,
 		Tags.ServedIn.DOUBLE_ROCKS_GLASS

--- a/src/lib/data/cocktails/russian-spring-punch.ts
+++ b/src/lib/data/cocktails/russian-spring-punch.ts
@@ -1,0 +1,63 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+import DICK_BRADSELL from '$lib/data/bartenders/dick-bradsell';
+
+const RUSSIAN_SPRING_PUNCH: Cocktail = {
+	title: 'Russian Spring Punch',
+	description: 'Vodka, crème de baies noires, champagne, lemon, simple syrup.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/russian-spring-punch.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/russian-spring-punch.png',
+	slug: 'russian-spring-punch',
+	createdBy: DICK_BRADSELL,
+	method: CocktailMethod.Shaken,
+	servedIn: ServedIn.HighballGlass,
+	ice: Ice.SmallCubes,
+	hasStraw: true,
+	ingredients: [
+		{
+			amount: '1.5oz',
+			ingredient: Ingredients.BaseSpirits.MONOPOLOWA
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Liqueurs.HOUSE_DARK_BERRY_CREME
+		},
+		{
+			amount: '2oz',
+			ingredient: Ingredients.BeerAndWine.CHAMPAGNE
+		},
+		{
+			amount: '.75oz',
+			ingredient: Ingredients.Citrus.LEMON
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.Syrups.RICH_SIMPLE_SYRUP
+		},
+		{
+			label: 'Garnish: Lemon wheel and blackberry',
+			ingredient: Ingredients.Citrus.LEMON_GARNISH
+		}
+	],
+	notes:
+		'Shake everything except champagne with ice. Strain over fresh ice in a highball glass and top with champagne.',
+	tags: [
+		Tags.BaseAlcohol.VODKA,
+		Tags.BaseAlcohol.WINE,
+		Tags.FlavorProfile.CITRUS,
+		Tags.FlavorProfile.FRUITY,
+		Tags.FlavorProfile.BUBBLY,
+		Tags.Technique.SHAKEN,
+		Tags.Style.SOUR,
+		Tags.Origin.CLASSIC,
+		Tags.ServedIn.HIGHBALL_GLASS
+	]
+};
+
+export default RUSSIAN_SPRING_PUNCH;

--- a/src/lib/data/ingredients/liqueurs.ts
+++ b/src/lib/data/ingredients/liqueurs.ts
@@ -95,7 +95,7 @@ const MARASCHINO_LIQUEUER: Ingredient = {
 	costPerOz: 40 / 25
 };
 const HOUSE_DARK_BERRY_CREME: Ingredient = {
-	title: 'House Dark Berry Crème',
+	title: 'Crème de Baies Noires',
 	slug: 'house-dark-berry-creme',
 	recipe: HOUSE_DARK_BERRY_CREME_RECIPE,
 	costPerOz: 15 / 21.667

--- a/src/lib/data/recipes/house-dark-berry-creme.ts
+++ b/src/lib/data/recipes/house-dark-berry-creme.ts
@@ -1,7 +1,7 @@
 import type { Recipe } from '$lib/types/recipes';
 
 const HOUSE_DARK_BERRY_CREME: Recipe = {
-	name: 'House Dark Berry Crème',
+	name: 'Crème de Baies Noires',
 	slug: 'house-dark-berry-creme',
 	description: 'A rich berry liqueur infused with vodka, lemon peel, and Ceylon black tea.',
 	ingredients: [

--- a/src/lib/enums/ice.ts
+++ b/src/lib/enums/ice.ts
@@ -4,3 +4,10 @@ export enum Ice {
 	SmallCubes = 'Small Cubes',
 	None = 'None'
 }
+
+export const iceLabels: Record<Ice, string> = {
+	[Ice.Crushed]: 'over crushed ice',
+	[Ice.LargeCube]: 'over a large cube',
+	[Ice.SmallCubes]: 'over small cubes',
+	[Ice.None]: 'up with no ice'
+};

--- a/src/lib/enums/methods.ts
+++ b/src/lib/enums/methods.ts
@@ -13,3 +13,11 @@ export const methodColors = {
 	[CocktailMethod.FlashBlended]: '#fae8ff',
 	[CocktailMethod.Blended]: '#fae8ff'
 };
+
+export const methodLabels: Record<CocktailMethod, string> = {
+	[CocktailMethod.Shaken]: 'Shaken',
+	[CocktailMethod.Stirred]: 'Stirred',
+	[CocktailMethod.Built]: 'Built',
+	[CocktailMethod.FlashBlended]: 'Flash blended',
+	[CocktailMethod.Blended]: 'Blended'
+};

--- a/src/lib/enums/served-in.ts
+++ b/src/lib/enums/served-in.ts
@@ -10,3 +10,16 @@ export enum ServedIn {
 	Mug = 'Mug',
 	JulepTin = 'Julep Tin'
 }
+
+export const servedInLabels: Record<ServedIn, string> = {
+	[ServedIn.CoupeGlass]: 'a coupe glass',
+	[ServedIn.DoubleRocksGlass]: 'a double rocks glass',
+	[ServedIn.SingleRocksGlass]: 'a single rocks glass',
+	[ServedIn.NickAndNoraGlass]: 'a Nick & Nora glass',
+	[ServedIn.HighballGlass]: 'a highball glass',
+	[ServedIn.FluteGlass]: 'a flute glass',
+	[ServedIn.TikiMug]: 'a tiki mug',
+	[ServedIn.PintGlass]: 'a pint glass',
+	[ServedIn.Mug]: 'a mug',
+	[ServedIn.JulepTin]: 'a julep tin'
+};

--- a/src/lib/utils/serving.ts
+++ b/src/lib/utils/serving.ts
@@ -1,0 +1,39 @@
+import { iceLabels } from '$lib/enums/ice';
+import { methodLabels } from '$lib/enums/methods';
+import { servedInLabels } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+
+export function buildServingSentence(cocktail: Cocktail): string | null {
+	const parts: string[] = [];
+
+	if (cocktail.method) {
+		parts.push(methodLabels[cocktail.method]);
+	}
+
+	const servingPieces: string[] = [];
+	if (cocktail.ice) {
+		servingPieces.push(iceLabels[cocktail.ice]);
+	}
+	if (cocktail.servedIn) {
+		servingPieces.push(`in ${servedInLabels[cocktail.servedIn]}`);
+	}
+
+	let servingClause = '';
+	if (servingPieces.length > 0) {
+		servingClause = `served ${servingPieces.join(' ')}`;
+	}
+	if (cocktail.hasStraw) {
+		servingClause = servingClause ? `${servingClause} with a straw` : 'served with a straw';
+	}
+
+	if (servingClause) {
+		parts.push(servingClause);
+	}
+
+	if (parts.length === 0) {
+		return null;
+	}
+
+	const sentence = parts.join(', ');
+	return `${sentence.charAt(0).toUpperCase()}${sentence.slice(1)}.`;
+}

--- a/src/routes/cocktails/[slug]/+page.svelte
+++ b/src/routes/cocktails/[slug]/+page.svelte
@@ -10,10 +10,12 @@
 	import type { Tag } from '$lib/types/tags';
 	import { getIngredientDisplayName, formatVariantIngredients } from '$lib/utils/ingredients';
 	import { calculateCocktailCost, formatCost, parseAmountToOz, applyTax } from '$lib/utils/cost';
+	import { buildServingSentence } from '$lib/utils/serving';
 	import { costMode } from '$lib/stores/costMode';
 
 	export let data: PageData;
 	const { cocktail, onSummer, onWinter, onTiki, pathsContainingCocktail } = data;
+	const servingSentence = buildServingSentence(cocktail);
 
 	const onAnyMenu = onSummer || onWinter || onTiki;
 	const hasMenusOrPaths = onAnyMenu || pathsContainingCocktail.length > 0;
@@ -155,17 +157,10 @@
 											</li>
 										{/each}
 									</ul>
-									{#if cocktail.method}
+									{#if servingSentence}
 										<div class="mt-4">
-											<span class="text-sm font-medium text-gray-600">
-												Method: {cocktail.method}
-											</span>
-										</div>
-									{/if}
-									{#if cocktail.servedIn}
-										<div class="mt-4">
-											<span class="text-sm font-medium text-gray-600">
-												Served in: {cocktail.servedIn}
+											<span class="text-sm font-bold text-gray-700">
+												{servingSentence}
 											</span>
 										</div>
 									{/if}

--- a/src/routes/paths/[slug]/+page.svelte
+++ b/src/routes/paths/[slug]/+page.svelte
@@ -3,6 +3,7 @@
 	import CocktailCard from '$lib/components/CocktailCard.svelte';
 	import ScrollToTop from '$lib/components/ScrollToTop.svelte';
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
+	import CopyLinkButton from '$lib/components/CopyLinkButton.svelte';
 	import { fade, fly } from 'svelte/transition';
 	import { getPathCost, formatCost } from '$lib/utils/cost';
 	import { costMode } from '$lib/stores/costMode';
@@ -42,7 +43,14 @@
 					class="w-full max-w-xs mx-auto object-contain rounded-xl"
 				/>
 			</div>
-			<h1 class="text-5xl font-bold text-gray-800 mb-4">{path.title}</h1>
+			<div class="flex items-center justify-center gap-3 mb-4">
+				<h1 class="text-5xl font-bold text-gray-800">{path.title}</h1>
+				<CopyLinkButton
+					url={typeof window !== 'undefined' ? window.location.href : ''}
+					ariaLabel="Copy link to {path.title} path"
+					size="md"
+				/>
+			</div>
 			<p class="text-2xl text-gray-600 font-medium mb-4">{path.subtitle}</p>
 			<p class="text-lg text-gray-700 max-w-2xl mx-auto">{path.description}</p>
 			{#if $costMode}


### PR DESCRIPTION
## Summary
- Add Bramble, El Diablo, Kir Royale, and Russian Spring Punch cocktails
- Replace method/served-in chips with a serving sentence on cocktail detail pages
- Add copy link button to path detail header and refine path descriptions
- Tweak Navy Grog and other recipes; rename House Dark Berry Crème

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run check` passes
- [ ] `npm run test` passes
- [ ] Verify new cocktails render on `/cocktails`
- [ ] Verify serving sentence renders on cocktail detail pages
- [ ] Verify copy link button works on path detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)