### PR TITLE
feat(cocktails): add Batched method and tag

### DIFF
--- a/src/lib/data/all-cocktails.ts
+++ b/src/lib/data/all-cocktails.ts
@@ -55,6 +55,7 @@ import JET_PILOT from '$lib/data/cocktails/jet-pilot';
 import JUNGLE_BIRD from '$lib/data/cocktails/jungle-bird';
 import KING_OF_KINGS from '$lib/data/cocktails/king-of-kings';
 import KIR_ROYALE from '$lib/data/cocktails/kir-royale';
+import KOLAWEIZEN from '$lib/data/cocktails/kolaweizen';
 import LAST_WORD from '$lib/data/cocktails/last-word';
 import LEMON_DROP from '$lib/data/cocktails/lemon-drop';
 import LOGGY_CAB from '$lib/data/cocktails/loggy-cab';
@@ -171,6 +172,7 @@ export const allCocktails: Cocktail[] = [
 	JUNGLE_BIRD,
 	KING_OF_KINGS,
 	KIR_ROYALE,
+	KOLAWEIZEN,
 	LAST_WORD,
 	LEMON_DROP,
 	LOGGY_CAB,

--- a/src/lib/data/bartenders/aaron-krauss.ts
+++ b/src/lib/data/bartenders/aaron-krauss.ts
@@ -3,8 +3,10 @@ import type { Bartender } from '$lib/types/bartenders';
 const AARON_KRAUSS: Bartender = {
 	name: 'Aaron Krauss',
 	slug: 'aaron-krauss',
+	imageUrl:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/bartenders/aaron-krauss.jpeg',
 	description:
-		"Proprietor of The Krauss Haus, a home bar in the wild suburbs. Aaron's originals lean heavily on the fantasy and sci-fi worlds his family loves — tiki riffs, warming winter drinks, and pantry-raiding experiments — and every one of his cocktails is tagged as an Original on this site."
+		"Aaron runs The Krauss Haus out of his home, where the bar is just an extension of the kitchen and friends are always welcome to pull up a stool. His originals — tagged as such on this site — usually start with whatever's in season, a story his family is into at the moment, or an ingredient he couldn't resist picking up. Expect tiki riffs, cozy winter pours, and the occasional pantry experiment."
 };
 
 export default AARON_KRAUSS;

--- a/src/lib/data/cocktails/canelazo.ts
+++ b/src/lib/data/cocktails/canelazo.ts
@@ -1,3 +1,4 @@
+import { CocktailMethod } from '$lib/enums/methods';
 import { ServedIn } from '$lib/enums/served-in';
 import type { Cocktail } from '$lib/types/cocktails';
 import { Ingredients } from '../all-ingredients';
@@ -12,6 +13,7 @@ const CANELAZO: Cocktail = {
 	thumbnailImagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/canelazo.png',
 	slug: 'canelazo',
+	method: CocktailMethod.Batched,
 	servedIn: ServedIn.Mug,
 	ice: Ice.Hot,
 	hasStraw: false,
@@ -46,6 +48,7 @@ const CANELAZO: Cocktail = {
 		Tags.FlavorProfile.SPICED,
 		Tags.FlavorProfile.CITRUS,
 		Tags.Temperature.HOT,
+		Tags.Technique.BATCHED,
 		Tags.Origin.FOLK,
 		Tags.AlcoholLevel.LOW,
 		Tags.ServedIn.MUG,

--- a/src/lib/data/cocktails/canelazo.ts
+++ b/src/lib/data/cocktails/canelazo.ts
@@ -13,7 +13,7 @@ const CANELAZO: Cocktail = {
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/canelazo.png',
 	slug: 'canelazo',
 	servedIn: ServedIn.Mug,
-	ice: Ice.None,
+	ice: Ice.Hot,
 	hasStraw: false,
 	servings: 4,
 	ingredients: [

--- a/src/lib/data/cocktails/caramel-apple-spice.ts
+++ b/src/lib/data/cocktails/caramel-apple-spice.ts
@@ -17,7 +17,7 @@ const CARAMEL_APPLE_SPICE: Cocktail = {
 	createdBy: AARON_KRAUSS,
 	method: CocktailMethod.Built,
 	servedIn: ServedIn.Mug,
-	ice: Ice.None,
+	ice: Ice.Hot,
 	hasStraw: false,
 	ingredients: [
 		{

--- a/src/lib/data/cocktails/gluhwein.ts
+++ b/src/lib/data/cocktails/gluhwein.ts
@@ -14,7 +14,7 @@ const GLUHWEIN: Cocktail = {
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/gluhwein.png',
 	slug: 'gluhwein',
 	servedIn: ServedIn.Mug,
-	ice: Ice.None,
+	ice: Ice.Hot,
 	hasStraw: false,
 	servings: 4,
 	ingredients: [

--- a/src/lib/data/cocktails/gluhwein.ts
+++ b/src/lib/data/cocktails/gluhwein.ts
@@ -1,3 +1,4 @@
+import { CocktailMethod } from '$lib/enums/methods';
 import { ServedIn } from '$lib/enums/served-in';
 import type { Cocktail } from '$lib/types/cocktails';
 import { Ingredients } from '../all-ingredients';
@@ -13,6 +14,7 @@ const GLUHWEIN: Cocktail = {
 	thumbnailImagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/gluhwein.png',
 	slug: 'gluhwein',
+	method: CocktailMethod.Batched,
 	servedIn: ServedIn.Mug,
 	ice: Ice.Hot,
 	hasStraw: false,
@@ -53,6 +55,7 @@ const GLUHWEIN: Cocktail = {
 		Tags.BaseAlcohol.BRANDY,
 		Tags.FlavorProfile.SPICED,
 		Tags.Temperature.HOT,
+		Tags.Technique.BATCHED,
 		Tags.Origin.FOLK,
 		Tags.ServedIn.MUG,
 		Tags.PrepTime.COMPLEX_PREP

--- a/src/lib/data/cocktails/highland-coffee.ts
+++ b/src/lib/data/cocktails/highland-coffee.ts
@@ -17,7 +17,7 @@ const HIGHLAND_COFFEE: Cocktail = {
 	createdBy: AARON_KRAUSS,
 	method: CocktailMethod.Built,
 	servedIn: ServedIn.Mug,
-	ice: Ice.None,
+	ice: Ice.Hot,
 	hasStraw: false,
 	ingredients: [
 		{

--- a/src/lib/data/cocktails/hot-toddy.ts
+++ b/src/lib/data/cocktails/hot-toddy.ts
@@ -15,7 +15,7 @@ const HOT_TODDY: Cocktail = {
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/hot-toddy.png',
 	method: CocktailMethod.Built,
 	servedIn: ServedIn.Mug,
-	ice: Ice.None,
+	ice: Ice.Hot,
 	hasStraw: false,
 	ingredients: [
 		{

--- a/src/lib/data/cocktails/kolaweizen.ts
+++ b/src/lib/data/cocktails/kolaweizen.ts
@@ -1,0 +1,41 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+
+const KOLAWEIZEN: Cocktail = {
+	title: 'Kolaweizen',
+	description: 'Hefeweizen, coca-cola.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/kolaweizen.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/kolaweizen.png',
+	slug: 'kolaweizen',
+	method: CocktailMethod.Built,
+	servedIn: ServedIn.PintGlass,
+	ice: Ice.None,
+	hasStraw: false,
+	ingredients: [
+		{
+			amount: '6oz',
+			ingredient: Ingredients.BeerAndWine.ERDINGER_WEISSBIER
+		},
+		{
+			amount: '6oz',
+			ingredient: Ingredients.Mixers.COCA_COLA
+		}
+	],
+	tags: [
+		Tags.BaseAlcohol.BEER,
+		Tags.FlavorProfile.BUBBLY,
+		Tags.Technique.BUILT,
+		Tags.Origin.FOLK,
+		Tags.ServedIn.PINT_GLASS,
+		Tags.AlcoholLevel.LOW,
+		Tags.PrepTime.SIMPLE_PREP
+	]
+};
+
+export default KOLAWEIZEN;

--- a/src/lib/data/cocktails/sangria.ts
+++ b/src/lib/data/cocktails/sangria.ts
@@ -1,3 +1,4 @@
+import { CocktailMethod } from '$lib/enums/methods';
 import { ServedIn } from '$lib/enums/served-in';
 import type { Cocktail } from '$lib/types/cocktails';
 import { Ingredients } from '../all-ingredients';
@@ -12,6 +13,7 @@ const SANGRIA: Cocktail = {
 	thumbnailImagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/sangria.png',
 	slug: 'sangria',
+	method: CocktailMethod.Batched,
 	servedIn: ServedIn.HighballGlass,
 	ice: Ice.SmallCubes,
 	hasStraw: false,
@@ -57,8 +59,9 @@ const SANGRIA: Cocktail = {
 		'Makes 4-5 servings. Combine all but soda water in pitcher. Let rest at least 2 hours in refrigerator. Pour with fruit over ice into wine glasses, and top with club soda.',
 	tags: [
 		Tags.BaseAlcohol.WINE,
-		Tags.Origin.FOLK,
 		Tags.BaseAlcohol.BRANDY,
+		Tags.Technique.BATCHED,
+		Tags.Origin.FOLK,
 		Tags.FlavorProfile.BUBBLY,
 		Tags.FlavorProfile.FRUITY,
 		Tags.ServedIn.HIGHBALL_GLASS,

--- a/src/lib/data/cocktails/tom-and-jerry.ts
+++ b/src/lib/data/cocktails/tom-and-jerry.ts
@@ -15,7 +15,7 @@ const TOM_AND_JERRY: Cocktail = {
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/tom-and-jerry.png',
 	method: CocktailMethod.Built,
 	servedIn: ServedIn.Mug,
-	ice: Ice.None,
+	ice: Ice.Hot,
 	hasStraw: false,
 	ingredients: [
 		{

--- a/src/lib/data/ingredients/beer-and-wine.ts
+++ b/src/lib/data/ingredients/beer-and-wine.ts
@@ -7,10 +7,15 @@ const BITBURGER_PILS: Ingredient = {
 	slug: 'bitburger-pils',
 	costPerOz: 19 / (11.2 * 12)
 };
+const ERDINGER_WEISSBIER: Ingredient = {
+	title: 'Erdinger Weißbier',
+	slug: 'erdinger-weissbier',
+	costPerOz: 8 / (16.9 * 4)
+};
 const GUINNESS_DRAUGHT: Ingredient = {
 	title: 'Guinness Draught',
 	slug: 'guinness-draught',
-	costPerOz: 18 / (8 * 14.9)
+	costPerOz: 18 / (14.9 * 8)
 };
 const MILLER_HIGH_LIFE: Ingredient = {
 	title: 'Miller High Life',
@@ -66,7 +71,13 @@ export const BEER_AND_WINE: IngredientCategory = {
 	subcategories: [
 		{
 			label: 'Beer',
-			ingredients: [BITBURGER_PILS, GUINNESS_DRAUGHT, MILLER_HIGH_LIFE, TECATE_MEXICAN_LAGER]
+			ingredients: [
+				BITBURGER_PILS,
+				ERDINGER_WEISSBIER,
+				GUINNESS_DRAUGHT,
+				MILLER_HIGH_LIFE,
+				TECATE_MEXICAN_LAGER
+			]
 		},
 		{
 			label: 'Wine',
@@ -82,6 +93,7 @@ export const BEER_AND_WINE: IngredientCategory = {
 export const INGREDIENTS = {
 	// Beer
 	BITBURGER_PILS,
+	ERDINGER_WEISSBIER,
 	GUINNESS_DRAUGHT,
 	MILLER_HIGH_LIFE,
 	TECATE_MEXICAN_LAGER,

--- a/src/lib/data/tags/technique.ts
+++ b/src/lib/data/tags/technique.ts
@@ -11,11 +11,13 @@ const STIRRED: Tag = { label: 'Stirred', category: TECHNIQUE, order: 2 };
 const BUILT: Tag = { label: 'Built in Glass', category: TECHNIQUE, order: 3 };
 const FLASH_BLENDED: Tag = { label: 'Flash Blended', category: TECHNIQUE, order: 4 };
 const BLENDED: Tag = { label: 'Blended', category: TECHNIQUE, order: 5 };
+const BATCHED: Tag = { label: 'Batched', category: TECHNIQUE, order: 6 };
 
 export const TAGS = {
 	STIRRED,
 	SHAKEN,
 	FLASH_BLENDED,
 	BLENDED,
-	BUILT
+	BUILT,
+	BATCHED
 };

--- a/src/lib/enums/ice.ts
+++ b/src/lib/enums/ice.ts
@@ -2,12 +2,14 @@ export enum Ice {
 	Crushed = 'Crushed',
 	LargeCube = 'Large Cube',
 	SmallCubes = 'Small Cubes',
-	None = 'None'
+	None = 'None',
+	Hot = 'Hot'
 }
 
 export const iceLabels: Record<Ice, string> = {
 	[Ice.Crushed]: 'over crushed ice',
 	[Ice.LargeCube]: 'over a large cube',
 	[Ice.SmallCubes]: 'over small cubes',
-	[Ice.None]: 'up with no ice'
+	[Ice.None]: 'up with no ice',
+	[Ice.Hot]: 'hot'
 };

--- a/src/lib/enums/methods.ts
+++ b/src/lib/enums/methods.ts
@@ -17,7 +17,7 @@ export const methodColors = {
 export const methodLabels: Record<CocktailMethod, string> = {
 	[CocktailMethod.Shaken]: 'Shaken',
 	[CocktailMethod.Stirred]: 'Stirred',
-	[CocktailMethod.Built]: 'Built',
+	[CocktailMethod.Built]: 'Built in glass',
 	[CocktailMethod.FlashBlended]: 'Flash blended',
 	[CocktailMethod.Blended]: 'Blended'
 };

--- a/src/lib/enums/methods.ts
+++ b/src/lib/enums/methods.ts
@@ -3,7 +3,8 @@ export enum CocktailMethod {
 	Stirred = 'Stirred',
 	Built = 'Built in Glass',
 	FlashBlended = 'Flash Blended',
-	Blended = 'Blended'
+	Blended = 'Blended',
+	Batched = 'Batched'
 }
 
 export const methodColors = {
@@ -11,7 +12,8 @@ export const methodColors = {
 	[CocktailMethod.Stirred]: '#dbeafe',
 	[CocktailMethod.Built]: '#dcfce7',
 	[CocktailMethod.FlashBlended]: '#fae8ff',
-	[CocktailMethod.Blended]: '#fae8ff'
+	[CocktailMethod.Blended]: '#fae8ff',
+	[CocktailMethod.Batched]: '#fed7aa'
 };
 
 export const methodLabels: Record<CocktailMethod, string> = {
@@ -19,5 +21,6 @@ export const methodLabels: Record<CocktailMethod, string> = {
 	[CocktailMethod.Stirred]: 'Stirred',
 	[CocktailMethod.Built]: 'Built in glass',
 	[CocktailMethod.FlashBlended]: 'Flash blended',
-	[CocktailMethod.Blended]: 'Blended'
+	[CocktailMethod.Blended]: 'Blended',
+	[CocktailMethod.Batched]: 'Batched'
 };

--- a/src/routes/bartenders/[slug]/+page.svelte
+++ b/src/routes/bartenders/[slug]/+page.svelte
@@ -40,7 +40,7 @@
 		>
 			<div class="p-8">
 				<header class="mb-4">
-					<div class="flex items-start gap-4">
+					<div class="flex items-center gap-4">
 						{#if bartender.imageUrl}
 							<img
 								src={bartender.imageUrl}


### PR DESCRIPTION
## Summary
- Adds `Batched` to `CocktailMethod` enum (with color + label) and a corresponding `BATCHED` technique tag
- Applies the new method/tag to Canelazo, Glühwein, and Sangria

## Test plan
- [x] `npm run check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] Visit /cocktails/canelazo, /cocktails/gluhwein, /cocktails/sangria — method shows "Batched"
- [x] Filter by Technique → Batched returns the three cocktails

🤖 Generated with [Claude Code](https://claude.com/claude-code)