### PR TITLE
feat: add Rum Runner, Tradewinds, stone fruit liqueur, and global search

### DIFF
--- a/src/lib/components/SearchModal.svelte
+++ b/src/lib/components/SearchModal.svelte
@@ -1,0 +1,350 @@
+<script lang="ts">
+	import { onMount, onDestroy, tick } from 'svelte';
+	import { fade, scale } from 'svelte/transition';
+	import { quintOut } from 'svelte/easing';
+	import { browser } from '$app/environment';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { searchAll, type SearchResult } from '$lib/data/all-searchable';
+
+	export let isOpen = false;
+	export let onClose: () => void = () => {};
+
+	let query = '';
+	let results: SearchResult[] = [];
+	let activeIndex = 0;
+	let inputEl: HTMLInputElement | null = null;
+	let listboxEl: HTMLUListElement | null = null;
+	let lastFocusedElement: HTMLElement | null = null;
+	const listboxId = 'search-results-listbox';
+	const inputId = 'search-modal-input';
+
+	$: results = query.trim().length > 0 ? searchAll(query, 15) : [];
+	$: if (results.length > 0 && activeIndex >= results.length) activeIndex = 0;
+
+	function handleInput() {
+		activeIndex = 0;
+	}
+
+	function selectResult(result: SearchResult) {
+		closeAndNavigate(result.item.href);
+	}
+
+	function closeAndNavigate(href: string) {
+		close();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		goto(resolve(href as any));
+	}
+
+	function close() {
+		isOpen = false;
+		onClose();
+	}
+
+	function resetState() {
+		query = '';
+		results = [];
+		activeIndex = 0;
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (!isOpen) return;
+
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			close();
+			return;
+		}
+
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			if (results.length === 0) return;
+			activeIndex = (activeIndex + 1) % results.length;
+			scrollActiveIntoView();
+			return;
+		}
+
+		if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			if (results.length === 0) return;
+			activeIndex = (activeIndex - 1 + results.length) % results.length;
+			scrollActiveIntoView();
+			return;
+		}
+
+		if (event.key === 'Home') {
+			if (results.length === 0) return;
+			event.preventDefault();
+			activeIndex = 0;
+			scrollActiveIntoView();
+			return;
+		}
+
+		if (event.key === 'End') {
+			if (results.length === 0) return;
+			event.preventDefault();
+			activeIndex = results.length - 1;
+			scrollActiveIntoView();
+			return;
+		}
+
+		if (event.key === 'Enter') {
+			if (results[activeIndex]) {
+				event.preventDefault();
+				selectResult(results[activeIndex]);
+			}
+			return;
+		}
+
+		if (event.key === 'Tab') {
+			// Trap focus inside the dialog (only two stops: input and close button)
+			const focusables = getFocusables();
+			if (focusables.length === 0) return;
+			const first = focusables[0];
+			const last = focusables[focusables.length - 1];
+			if (event.shiftKey && document.activeElement === first) {
+				event.preventDefault();
+				last.focus();
+			} else if (!event.shiftKey && document.activeElement === last) {
+				event.preventDefault();
+				first.focus();
+			}
+		}
+	}
+
+	function getFocusables(): HTMLElement[] {
+		if (!browser) return [];
+		const root = document.getElementById('search-modal-root');
+		if (!root) return [];
+		return Array.from(
+			root.querySelectorAll<HTMLElement>(
+				'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+			)
+		);
+	}
+
+	function scrollActiveIntoView() {
+		if (!browser || !listboxEl) return;
+		const el = listboxEl.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`);
+		el?.scrollIntoView({ block: 'nearest' });
+	}
+
+	function handleBackdropClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) close();
+	}
+
+	$: if (isOpen && browser) {
+		lastFocusedElement = (document.activeElement as HTMLElement) ?? null;
+		tick().then(() => inputEl?.focus());
+	}
+
+	$: if (!isOpen && browser) {
+		const el = lastFocusedElement;
+		setTimeout(() => {
+			resetState();
+			el?.focus?.();
+		}, 200);
+	}
+
+	onMount(() => {
+		if (browser) window.addEventListener('keydown', handleKeydown);
+	});
+
+	onDestroy(() => {
+		if (browser) window.removeEventListener('keydown', handleKeydown);
+	});
+
+	function typeBadgeClass(type: string): string {
+		switch (type) {
+			case 'cocktail':
+				return 'bg-amber-100 text-amber-800';
+			case 'recipe':
+				return 'bg-emerald-100 text-emerald-800';
+			case 'path':
+				return 'bg-purple-100 text-purple-800';
+			case 'party':
+				return 'bg-pink-100 text-pink-800';
+			case 'bartender':
+				return 'bg-blue-100 text-blue-800';
+			case 'menu':
+				return 'bg-orange-100 text-orange-800';
+			case 'page':
+				return 'bg-gray-200 text-gray-700';
+			default:
+				return 'bg-gray-100 text-gray-700';
+		}
+	}
+</script>
+
+{#if isOpen}
+	<div
+		id="search-modal-root"
+		class="fixed inset-0 bg-gray-900/60 backdrop-blur-sm flex items-start justify-center z-50 px-4 pt-[10vh] sm:pt-[15vh]"
+		on:click={handleBackdropClick}
+		role="presentation"
+		transition:fade={{ duration: 200 }}
+	>
+		<div
+			class="bg-white rounded-2xl shadow-2xl w-full max-w-2xl overflow-hidden flex flex-col max-h-[80vh]"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="search-modal-title"
+			transition:scale={{ duration: 200, easing: quintOut, start: 0.96 }}
+		>
+			<h2 id="search-modal-title" class="sr-only">Search The Krauss Haus</h2>
+
+			<div class="flex items-center gap-3 px-4 py-3 border-b border-gray-100">
+				<svg
+					class="h-5 w-5 text-gray-400 shrink-0"
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+					aria-hidden="true"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z"
+					/>
+				</svg>
+				<input
+					bind:this={inputEl}
+					bind:value={query}
+					on:input={handleInput}
+					id={inputId}
+					type="text"
+					placeholder="Search cocktails, recipes, paths…"
+					class="flex-1 bg-transparent border-0 outline-none text-gray-800 placeholder-gray-400 text-base py-1"
+					autocomplete="off"
+					spellcheck="false"
+					role="combobox"
+					aria-expanded={results.length > 0}
+					aria-controls={listboxId}
+					aria-activedescendant={results.length > 0 ? `search-result-${activeIndex}` : undefined}
+					aria-autocomplete="list"
+					aria-label="Search The Krauss Haus"
+				/>
+				<button
+					type="button"
+					class="cursor-pointer text-gray-400 hover:text-gray-600 transition-colors p-1 rounded-md"
+					on:click={close}
+					aria-label="Close search"
+				>
+					<svg
+						class="h-5 w-5"
+						xmlns="http://www.w3.org/2000/svg"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+						aria-hidden="true"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M6 18L18 6M6 6l12 12"
+						/>
+					</svg>
+				</button>
+			</div>
+
+			<div class="overflow-y-auto" aria-live="polite" aria-atomic="false">
+				{#if query.trim().length === 0}
+					<p class="px-4 py-8 text-sm text-center text-gray-500">
+						Start typing to search cocktails, recipes, paths, parties, bartenders, menus, and pages.
+					</p>
+				{:else if results.length === 0}
+					<p class="px-4 py-8 text-sm text-center text-gray-500">
+						No results for <span class="font-medium text-gray-700">"{query}"</span>.
+					</p>
+				{:else}
+					<ul
+						bind:this={listboxEl}
+						id={listboxId}
+						role="listbox"
+						aria-label="Search results"
+						class="py-1"
+					>
+						{#each results as result, i (result.item.href)}
+							<li
+								id="search-result-{i}"
+								role="option"
+								aria-selected={i === activeIndex}
+								data-index={i}
+							>
+								<button
+									type="button"
+									class="w-full cursor-pointer text-left flex items-center gap-3 px-4 py-3 transition-colors {i ===
+									activeIndex
+										? 'bg-amber-50'
+										: 'hover:bg-gray-50'}"
+									on:click={() => selectResult(result)}
+									on:mouseenter={() => (activeIndex = i)}
+									tabindex="-1"
+								>
+									{#if result.item.imagePath}
+										<img
+											src={result.item.imagePath}
+											alt=""
+											class="h-12 w-12 rounded-md object-contain shrink-0 bg-gray-100"
+											loading="lazy"
+										/>
+									{:else}
+										<div
+											class="h-12 w-12 rounded-md shrink-0 bg-gray-100 flex items-center justify-center"
+											aria-hidden="true"
+										>
+											<svg
+												class="h-5 w-5 text-gray-400"
+												xmlns="http://www.w3.org/2000/svg"
+												fill="none"
+												viewBox="0 0 24 24"
+												stroke="currentColor"
+											>
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													stroke-width="2"
+													d="M4 6h16M4 12h16M4 18h7"
+												/>
+											</svg>
+										</div>
+									{/if}
+									<div class="flex-1 min-w-0">
+										<div class="flex items-center gap-2">
+											<span class="font-medium text-gray-800 truncate">
+												{result.item.title}
+											</span>
+											<span
+												class="text-[10px] uppercase tracking-wider font-semibold px-1.5 py-0.5 rounded shrink-0 {typeBadgeClass(
+													result.item.type
+												)}"
+											>
+												{result.item.typeLabel}
+											</span>
+										</div>
+										{#if result.item.description}
+											<p class="text-sm text-gray-500 truncate">
+												{result.item.description}
+											</p>
+										{/if}
+									</div>
+								</button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+
+			<div
+				class="hidden sm:flex items-center gap-4 px-4 py-2 border-t border-gray-100 text-xs text-gray-400"
+			>
+				<span><kbd class="font-sans">↑</kbd> <kbd class="font-sans">↓</kbd> to navigate</span>
+				<span><kbd class="font-sans">↵</kbd> to select</span>
+				<span><kbd class="font-sans">esc</kbd> to close</span>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/data/all-cocktails.ts
+++ b/src/lib/data/all-cocktails.ts
@@ -90,6 +90,7 @@ import RADLER from '$lib/data/cocktails/radler';
 import RAMOS_GIN_FIZZ from '$lib/data/cocktails/ramos-gin-fizz';
 import RATTLE_SKULL from '$lib/data/cocktails/rattle-skull';
 import RUM_BARREL from '$lib/data/cocktails/rum-barrel';
+import RUM_RUNNER from '$lib/data/cocktails/rum-runner';
 import RUSSIAN_SPRING_PUNCH from '$lib/data/cocktails/russian-spring-punch';
 import SALTY_DOG from '$lib/data/cocktails/salty-dog';
 import SANGRIA from '$lib/data/cocktails/sangria';
@@ -108,6 +109,7 @@ import TI_PUNCH from '$lib/data/cocktails/ti-punch';
 import TIA_MIA from '$lib/data/cocktails/tia-mia';
 import TOM_AND_JERRY from '$lib/data/cocktails/tom-and-jerry';
 import TORONTO from '$lib/data/cocktails/toronto';
+import TRADEWINDS from '$lib/data/cocktails/tradewinds';
 import TRINIDAD_SOUR from '$lib/data/cocktails/trinidad-sour';
 import VIEUX_CARRE from '$lib/data/cocktails/vieux-carre';
 import WHISKEY_GINGER from '$lib/data/cocktails/whiskey-ginger';
@@ -207,6 +209,7 @@ export const allCocktails: Cocktail[] = [
 	RAMOS_GIN_FIZZ,
 	RATTLE_SKULL,
 	RUM_BARREL,
+	RUM_RUNNER,
 	RUSSIAN_SPRING_PUNCH,
 	SALTY_DOG,
 	SANGRIA,
@@ -225,6 +228,7 @@ export const allCocktails: Cocktail[] = [
 	TIA_MIA,
 	TOM_AND_JERRY,
 	TORONTO,
+	TRADEWINDS,
 	TRINIDAD_SOUR,
 	VIEUX_CARRE,
 	WHISKEY_GINGER,

--- a/src/lib/data/all-recipes.ts
+++ b/src/lib/data/all-recipes.ts
@@ -27,6 +27,7 @@ import LIMONCELLO from '$lib/data/recipes/limoncello';
 import PEPPERMINT_VODKA from '$lib/data/recipes/peppermint-vodka';
 import PERSIAN_SPICE_LIQUEUR from '$lib/data/recipes/persian-spice-liqueur';
 import SPICED_TEA from '$lib/data/recipes/spiced-tea';
+import STONE_FRUIT_LIQUEUR from '$lib/data/recipes/stone-fruit-liqueur';
 import CRANBERRY_CORDIAL from '$lib/data/recipes/cranberry-cordial';
 
 // Syrups (excluding Caramel Syrup and Tom and Jerry Batter which go to "Other")
@@ -56,7 +57,8 @@ export const infusions: Recipe[] = [
 	JALAPENO_TEQUILA,
 	LIMONCELLO,
 	PEPPERMINT_VODKA,
-	PERSIAN_SPICE_LIQUEUR
+	PERSIAN_SPICE_LIQUEUR,
+	STONE_FRUIT_LIQUEUR
 ];
 
 // Other recipes (special category for Caramel Syrup and Tom and Jerry Batter)

--- a/src/lib/data/all-searchable.ts
+++ b/src/lib/data/all-searchable.ts
@@ -1,0 +1,240 @@
+import { allCocktails } from './all-cocktails';
+import { allRecipes } from './all-recipes';
+import { allPaths } from './all-paths';
+import { allParties } from './all-parties';
+import { allBartenders } from './all-bartenders';
+import { menuConfig } from './menu-config';
+import { getIngredientDisplayName } from '$lib/utils/ingredients';
+
+export type SearchableType =
+	| 'cocktail'
+	| 'recipe'
+	| 'path'
+	| 'party'
+	| 'bartender'
+	| 'menu'
+	| 'page';
+
+export interface SearchableItem {
+	type: SearchableType;
+	typeLabel: string;
+	title: string;
+	description?: string;
+	href: string;
+	imagePath?: string;
+	keywords?: string[];
+}
+
+function cocktailItems(): SearchableItem[] {
+	return allCocktails.map((c) => {
+		const tagLabels = c.tags?.map((t) => t.label) ?? [];
+		const ingredientNames =
+			c.ingredients?.map((i) => (typeof i === 'string' ? i : getIngredientDisplayName(i))) ?? [];
+		const keywords = [c.subtitle, ...tagLabels, ...ingredientNames, c.method].filter(
+			(k): k is string => Boolean(k)
+		);
+		return {
+			type: 'cocktail',
+			typeLabel: 'Cocktail',
+			title: c.title,
+			description: c.description,
+			href: `/cocktails/${c.slug}`,
+			imagePath: c.thumbnailImagePath || c.imagePath,
+			keywords
+		};
+	});
+}
+
+function recipeItems(): SearchableItem[] {
+	return allRecipes.map((r) => ({
+		type: 'recipe',
+		typeLabel: 'Recipe',
+		title: r.name,
+		description: r.description,
+		href: `/recipes/${r.slug}`,
+		keywords: r.ingredients
+	}));
+}
+
+function pathItems(): SearchableItem[] {
+	return allPaths.map((p) => ({
+		type: 'path',
+		typeLabel: 'Path',
+		title: p.title,
+		description: p.description,
+		href: `/paths/${p.slug}`,
+		imagePath: p.imagePath,
+		keywords: [p.subtitle, ...p.cocktails.map((c) => c.title)].filter((k): k is string =>
+			Boolean(k)
+		)
+	}));
+}
+
+function partyItems(): SearchableItem[] {
+	return allParties.map((p) => ({
+		type: 'party',
+		typeLabel: 'Party',
+		title: p.name,
+		description: p.description,
+		href: `/parties/${p.slug}`,
+		keywords: p.schedule.map((s) => s.cocktail.title)
+	}));
+}
+
+function bartenderItems(): SearchableItem[] {
+	return allBartenders.map((b) => ({
+		type: 'bartender',
+		typeLabel: 'Bartender',
+		title: b.name,
+		description: b.description,
+		href: `/bartenders/${b.slug}`,
+		imagePath: b.imageUrl
+	}));
+}
+
+function menuItems(): SearchableItem[] {
+	return Object.entries(menuConfig).map(([slug, config]) => ({
+		type: 'menu',
+		typeLabel: 'Menu',
+		title: config.title,
+		description: config.subtitle,
+		href: `/menu/${slug}`,
+		keywords: config.categories.flatMap((cat) => [cat.title, ...cat.cocktails.map((c) => c.title)])
+	}));
+}
+
+function pageItems(): SearchableItem[] {
+	return [
+		{
+			type: 'page',
+			typeLabel: 'Page',
+			title: 'Home',
+			description: 'The Krauss Haus home page',
+			href: '/'
+		},
+		{
+			type: 'page',
+			typeLabel: 'Page',
+			title: 'All Cocktails',
+			description: 'Browse the complete collection of cocktails',
+			href: '/cocktails'
+		},
+		{
+			type: 'page',
+			typeLabel: 'Page',
+			title: 'Recipes',
+			description: 'Syrups, infusions, and other house recipes',
+			href: '/recipes'
+		},
+		{
+			type: 'page',
+			typeLabel: 'Page',
+			title: 'Cocktail Paths',
+			description: 'Discover cocktails through guided paths',
+			href: '/paths'
+		},
+		{
+			type: 'page',
+			typeLabel: 'Page',
+			title: 'Parties',
+			description: 'Past and upcoming cocktail parties',
+			href: '/parties'
+		},
+		{
+			type: 'page',
+			typeLabel: 'Page',
+			title: 'Bartenders',
+			description: 'Bartenders and bars whose drinks inspire the menu',
+			href: '/bartenders'
+		},
+		{
+			type: 'page',
+			typeLabel: 'Page',
+			title: 'Ingredients',
+			description: 'Browse all ingredients used across the menu',
+			href: '/ingredients'
+		},
+		{
+			type: 'page',
+			typeLabel: 'Page',
+			title: 'Spirit Dilution Calculator',
+			description: 'Calculate dilution and ABV for batched spirits',
+			href: '/spirit-dilution-calculator',
+			keywords: ['abv', 'proof', 'calculator', 'dilution']
+		}
+	];
+}
+
+export const allSearchable: SearchableItem[] = [
+	...pageItems(),
+	...menuItems(),
+	...pathItems(),
+	...cocktailItems(),
+	...recipeItems(),
+	...partyItems(),
+	...bartenderItems()
+];
+
+function tokenize(query: string): string[] {
+	return query
+		.toLowerCase()
+		.trim()
+		.split(/\s+/)
+		.filter((t) => t.length > 0);
+}
+
+function itemHaystack(item: SearchableItem): string {
+	return [item.title, item.description, ...(item.keywords ?? [])]
+		.filter(Boolean)
+		.join(' ')
+		.toLowerCase();
+}
+
+const typeRank: Record<SearchableType, number> = {
+	cocktail: 0,
+	menu: 1,
+	path: 2,
+	recipe: 3,
+	bartender: 4,
+	party: 5,
+	page: 6
+};
+
+export interface SearchResult {
+	item: SearchableItem;
+	score: number;
+}
+
+export function searchAll(query: string, limit = 40): SearchResult[] {
+	const tokens = tokenize(query);
+	if (tokens.length === 0) return [];
+
+	const results: SearchResult[] = [];
+	for (const item of allSearchable) {
+		const haystack = itemHaystack(item);
+		const title = item.title.toLowerCase();
+
+		let score = 0;
+		let matchedAll = true;
+		for (const token of tokens) {
+			if (!haystack.includes(token)) {
+				matchedAll = false;
+				break;
+			}
+			if (title.startsWith(token)) score += 100;
+			else if (title.includes(token)) score += 50;
+			else score += 10;
+		}
+		if (!matchedAll) continue;
+		results.push({ item, score });
+	}
+
+	results.sort((a, b) => {
+		if (b.score !== a.score) return b.score - a.score;
+		const typeDiff = typeRank[a.item.type] - typeRank[b.item.type];
+		if (typeDiff !== 0) return typeDiff;
+		return a.item.title.localeCompare(b.item.title);
+	});
+
+	return results.slice(0, limit);
+}

--- a/src/lib/data/cocktail-paths/royal.ts
+++ b/src/lib/data/cocktail-paths/royal.ts
@@ -14,9 +14,9 @@ export const ROYAL: CocktailPath = {
 	description:
 		'Every sip should feel like an indulgence. This path opens with a lavish cascade of fruit and liqueur, melts into creamy tropical bliss, deepens through rich multi-spirit warmth and a dessert you can drink, then finishes with a velvety, cream-topped crown jewel. These are drinks that reward you for going all in.',
 	cocktails: [
+		KING_OF_KINGS,
 		SINGAPORE_SLING,
 		PAINKILLER,
-		KING_OF_KINGS,
 		CHOCOLATE_COVERED_CHERRIES,
 		RAMOS_GIN_FIZZ
 	]

--- a/src/lib/data/cocktail-paths/warrior.ts
+++ b/src/lib/data/cocktail-paths/warrior.ts
@@ -13,5 +13,5 @@ export const WARRIOR: CocktailPath = {
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/warrior.jpeg',
 	description:
 		'The spirit leads and everything else falls in line. This path opens on a sweetened bourbon foundation, escalates into three-rum tropical strength, cools through crushed-ice mint and bourbon, warms again with smoke and honeyed ginger, and arrives at austere, anise-tinged power. Each step strips away a little more, demanding respect for the base spirit.',
-	cocktails: [OLD_FASHIONED, NAVY_GROG, MINT_JULEP, PENICILLIN, SAZERAC]
+	cocktails: [OLD_FASHIONED, MINT_JULEP, NAVY_GROG, PENICILLIN, SAZERAC]
 };

--- a/src/lib/data/cocktails/mai-tai.ts
+++ b/src/lib/data/cocktails/mai-tai.ts
@@ -8,7 +8,8 @@ import TRADER_VIC from '$lib/data/bartenders/trader-vic';
 
 const MAI_TAI: Cocktail = {
 	title: 'Mai Tai',
-	description: 'Jamaican rum, blended rum, cachaca, orange curaçao, orgeat, lime, demerara syrup.',
+	description:
+		'Jamaican rum, blended rum, cachaca, dry curaçao, cointreau, orgeat, lime, demerara syrup.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/mai-tai.png',
 	thumbnailImagePath:
@@ -33,11 +34,15 @@ const MAI_TAI: Cocktail = {
 			ingredient: Ingredients.BaseSpirits.PLANTERAY_OFTD
 		},
 		{
-			amount: '.4oz',
+			amount: '.25oz',
 			ingredient: Ingredients.Liqueurs.DRY_CURACAO
 		},
 		{
-			amount: '.6oz',
+			amount: '.25oz',
+			ingredient: Ingredients.Liqueurs.COINTREAU
+		},
+		{
+			amount: '.5oz',
 			ingredient: Ingredients.Syrups.ORGEAT
 		},
 		{
@@ -58,7 +63,7 @@ const MAI_TAI: Cocktail = {
 		}
 	],
 	notes:
-		"This uses a custom rum blend that has been tweaked to perfection. With using homemade dry curacao, the orange flavor pops a bit more, so it's reduced from .5oz to .4oz. Just eyeball it based on a .5oz measurement. Same thing with increasing orgeat to .6oz (to balance the curacao changes).",
+		'This uses a custom rum blend that has been tweaked to perfection. The orange curaçao is split between homemade dry curaçao (.25oz) and Cointreau (.25oz) to round out the orange flavor.',
 	tags: [
 		Tags.BaseAlcohol.RUM,
 		Tags.FlavorProfile.CITRUS,

--- a/src/lib/data/cocktails/missionarys-downfall.ts
+++ b/src/lib/data/cocktails/missionarys-downfall.ts
@@ -8,7 +8,7 @@ import DONN_THE_BEACHCOMBER from '$lib/data/bartenders/donn-beach';
 
 const MISSIONARYS_DOWNFALL: Cocktail = {
 	title: "Missionary's Downfall",
-	description: 'Light rum, peach liqueur, mint, pineapple, honey syrup, lime.',
+	description: 'Light rum, stone fruit liqueur, mint, pineapple, honey syrup, lime.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/missionarys-downfall.png',
 	thumbnailImagePath:
@@ -25,8 +25,8 @@ const MISSIONARYS_DOWNFALL: Cocktail = {
 			ingredient: Ingredients.BaseSpirits.PLANTERAY_3_STARS
 		},
 		{
-			amount: '.25oz',
-			ingredient: Ingredients.Liqueurs.DRY_CURACAO
+			amount: '.5oz',
+			ingredient: Ingredients.Liqueurs.STONE_FRUIT_LIQUEUR
 		},
 		{
 			label: '12 Large mint leaves',
@@ -39,10 +39,6 @@ const MISSIONARYS_DOWNFALL: Cocktail = {
 		{
 			amount: '1oz',
 			ingredient: Ingredients.Syrups.HONEY_SYRUP
-		},
-		{
-			amount: '.25oz',
-			ingredient: Ingredients.Syrups.RICH_SIMPLE_SYRUP
 		},
 		{
 			amount: '.5oz',

--- a/src/lib/data/cocktails/rum-runner.ts
+++ b/src/lib/data/cocktails/rum-runner.ts
@@ -1,0 +1,82 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+
+const RUM_RUNNER: Cocktail = {
+	title: 'Rum Runner',
+	description:
+		'Jamaican rum blend, stone fruit liqueur, dark berry crème, pineapple, grenadine, lime, orange.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/rum-runner.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/rum-runner.png',
+	slug: 'rum-runner',
+	method: CocktailMethod.Shaken,
+	servedIn: ServedIn.HighballGlass,
+	ice: Ice.Crushed,
+	hasStraw: true,
+	ingredients: [
+		{
+			amount: '1oz',
+			ingredient: Ingredients.BaseSpirits.CORUBA
+		},
+		{
+			amount: '.75oz',
+			ingredient: Ingredients.BaseSpirits.APPLETON_ESTATE_SIGNATURE
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.BaseSpirits.WRAY_AND_NEPHEW
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Liqueurs.STONE_FRUIT_LIQUEUR
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Liqueurs.HOUSE_DARK_BERRY_CREME
+		},
+		{
+			amount: '1oz',
+			ingredient: Ingredients.Citrus.PINEAPPLE
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.Syrups.GRENADINE
+		},
+		{
+			amount: '.75oz',
+			ingredient: Ingredients.Citrus.LIME
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Citrus.ORANGE
+		},
+		{
+			label: 'Garnish: Orange wheel',
+			ingredient: Ingredients.Citrus.ORANGE_GARNISH
+		},
+		{
+			label: 'Garnish: Maraschino cherry',
+			ingredient: Ingredients.Other.MARASCHINO_CHERRY
+		}
+	],
+	notes:
+		'Built in 1972 at the Holiday Isle Tiki Bar in the Florida Keys. The house stone fruit liqueur replaces the original crème de banane.',
+	tags: [
+		Tags.BaseAlcohol.RUM,
+		Tags.FlavorProfile.FRUITY,
+		Tags.FlavorProfile.CITRUS,
+		Tags.Technique.SHAKEN,
+		Tags.Style.TIKI,
+		Tags.Origin.CLASSIC,
+		Tags.ServedIn.DOUBLE_ROCKS_GLASS,
+		Tags.PrepTime.COMPLEX_PREP,
+		Tags.AlcoholLevel.HIGH
+	]
+};
+
+export default RUM_RUNNER;

--- a/src/lib/data/cocktails/tia-mia.ts
+++ b/src/lib/data/cocktails/tia-mia.ts
@@ -8,7 +8,7 @@ import IVY_MIX from '$lib/data/bartenders/ivy-mix';
 
 const TIA_MIA: Cocktail = {
 	title: 'Tia Mia',
-	description: 'Mezcal, jamaican rum, cointreau, orgeat, lime.',
+	description: 'Mezcal, jamaican rum, dry curaçao, orgeat, lime.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/tia-mia.png',
 	thumbnailImagePath:
@@ -30,7 +30,7 @@ const TIA_MIA: Cocktail = {
 		},
 		{
 			amount: '.5oz',
-			ingredient: Ingredients.Liqueurs.COINTREAU
+			ingredient: Ingredients.Liqueurs.DRY_CURACAO
 		},
 		{
 			amount: '.5oz',

--- a/src/lib/data/cocktails/tradewinds.ts
+++ b/src/lib/data/cocktails/tradewinds.ts
@@ -1,0 +1,60 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+
+const TRADEWINDS: Cocktail = {
+	title: 'Tradewinds',
+	description: 'Jamaican rum blend, stone fruit liqueur, lemon, coconut cream.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/tradewinds.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/tradewinds.png',
+	slug: 'tradewinds',
+	method: CocktailMethod.FlashBlended,
+	servedIn: ServedIn.HighballGlass,
+	ice: Ice.Crushed,
+	hasStraw: true,
+	ingredients: [
+		{
+			amount: '1oz',
+			ingredient: Ingredients.BaseSpirits.APPLETON_ESTATE_SIGNATURE
+		},
+		{
+			amount: '1oz',
+			ingredient: Ingredients.BaseSpirits.CORUBA
+		},
+		{
+			amount: '1oz',
+			ingredient: Ingredients.Liqueurs.STONE_FRUIT_LIQUEUR
+		},
+		{
+			amount: '1oz',
+			ingredient: Ingredients.Citrus.LEMON
+		},
+		{
+			amount: '1oz',
+			ingredient: Ingredients.Other.CREAM_OF_COCONUT
+		},
+		{
+			label: 'Garnish: Lemon wheel',
+			ingredient: Ingredients.Citrus.LEMON_GARNISH
+		}
+	],
+	notes: 'The house stone fruit liqueur replaces the traditional apricot liqueur.',
+	tags: [
+		Tags.BaseAlcohol.RUM,
+		Tags.FlavorProfile.CREAMY,
+		Tags.FlavorProfile.FRUITY,
+		Tags.FlavorProfile.CITRUS,
+		Tags.Technique.FLASH_BLENDED,
+		Tags.Style.TIKI,
+		Tags.Origin.CLASSIC,
+		Tags.AlcoholLevel.HIGH,
+		Tags.ServedIn.HIGHBALL_GLASS
+	]
+};
+
+export default TRADEWINDS;

--- a/src/lib/data/ingredients/liqueurs.ts
+++ b/src/lib/data/ingredients/liqueurs.ts
@@ -6,6 +6,7 @@ import FALERNUM_RECIPE from '$lib/data/recipes/falernum';
 import PERSIAN_SPICE_LIQUEUR_RECIPE from '$lib/data/recipes/persian-spice-liqueur';
 import DRY_CURACAO_RECIPE from '$lib/data/recipes/dry-curacao';
 import HOUSE_DARK_BERRY_CREME_RECIPE from '$lib/data/recipes/house-dark-berry-creme';
+import STONE_FRUIT_LIQUEUR_RECIPE from '$lib/data/recipes/stone-fruit-liqueur';
 
 // Amaro
 const AMARO_LUCANO: Ingredient = {
@@ -93,6 +94,12 @@ const MARASCHINO_LIQUEUER: Ingredient = {
 	title: 'Maraschino Liqueuer',
 	slug: 'maraschino-liqueuer',
 	costPerOz: 40 / 25
+};
+const STONE_FRUIT_LIQUEUR: Ingredient = {
+	title: 'Stone Fruit Liqueur',
+	slug: 'stone-fruit-liqueur',
+	recipe: STONE_FRUIT_LIQUEUR_RECIPE,
+	costPerOz: 11 / 25
 };
 const HOUSE_DARK_BERRY_CREME: Ingredient = {
 	title: 'Crème de Baies Noires',
@@ -186,7 +193,8 @@ export const LIQUEURS: IngredientCategory = {
 				COINTREAU,
 				CHERRY_HEERING,
 				HOUSE_DARK_BERRY_CREME,
-				MARASCHINO_LIQUEUER
+				MARASCHINO_LIQUEUER,
+				STONE_FRUIT_LIQUEUR
 			]
 		},
 		{
@@ -228,6 +236,7 @@ export const INGREDIENTS = {
 	CHERRY_HEERING,
 	HOUSE_DARK_BERRY_CREME,
 	MARASCHINO_LIQUEUER,
+	STONE_FRUIT_LIQUEUR,
 
 	// Nut & Spice
 	ALLSPICE_DRAM,

--- a/src/lib/data/recipes/stone-fruit-liqueur.ts
+++ b/src/lib/data/recipes/stone-fruit-liqueur.ts
@@ -1,0 +1,23 @@
+import type { Recipe } from '$lib/types/recipes';
+
+const STONE_FRUIT_LIQUEUR: Recipe = {
+	name: 'Stone Fruit Liqueur',
+	slug: 'stone-fruit-liqueur',
+	description: 'A house liqueur with notes of ripe peach and apricot.',
+	ingredients: [
+		'250 ml 95% ABV neutral spirit',
+		'200 ml water',
+		'250 g peach, chopped, with skin',
+		'150 g apricot, chopped, with skin',
+		'300 g sugar',
+		'.5 oz amaretto',
+		'1 strip lemon peel, with minimal white pith',
+		'2 tsp lemon juice',
+		'Tiny pinch of salt'
+	],
+	instructions:
+		'Combine the 95% ABV spirit with the water to make about 450 ml of diluted spirit at roughly 53% ABV. In a clean jar, combine the chopped peach, chopped apricot, and sugar, then refrigerate for 24 hours to macerate. Add the diluted spirit and lemon peel, then infuse for 5-8 days, tasting toward the end of that window. Strain and fine-strain the liqueur, then stir in the amaretto, lemon juice, and a tiny pinch of salt. Let rest for 1-2 weeks before using.',
+	notes: 'Refrigerate for best quality.'
+};
+
+export default STONE_FRUIT_LIQUEUR;

--- a/src/lib/data/tiki-menu.ts
+++ b/src/lib/data/tiki-menu.ts
@@ -12,8 +12,8 @@ import PAINKILLER from '$lib/data/cocktails/painkiller';
 import DESERT_DREAMS from '$lib/data/cocktails/desert-dreams';
 import SATURN from '$lib/data/cocktails/saturn';
 import SINGAPORE_SLING from '$lib/data/cocktails/singapore-sling';
+import RUM_BARREL from '$lib/data/cocktails/rum-barrel';
 import THREE_DOTS_AND_A_DASH from '$lib/data/cocktails/three-dots-and-a-dash';
-import ZOMBIE from '$lib/data/cocktails/zombie';
 import LOST_LAKE from '$lib/data/cocktails/lost-lake';
 import NAVY_GROG from '$lib/data/cocktails/navy-grog';
 import DONGA_PUNCH from '$lib/data/cocktails/donga-punch';
@@ -38,7 +38,7 @@ export const categories: Category[] = [
 			tertiary: '#fdf2f8',
 			variationText: '#581c87'
 		},
-		cocktails: [NAVY_GROG, LOST_LAKE, MAI_TAI, THREE_DOTS_AND_A_DASH, COBRAS_FANG, ZOMBIE]
+		cocktails: [NAVY_GROG, LOST_LAKE, MAI_TAI, THREE_DOTS_AND_A_DASH, COBRAS_FANG, RUM_BARREL]
 	},
 	{
 		title: 'Not Just Rum',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,8 +3,19 @@
 	import '../app.css';
 	import { page } from '$app/stores';
 	import { toggleCostMode, toastMessage } from '$lib/stores/costMode';
+	import SearchModal from '$lib/components/SearchModal.svelte';
 
 	let { children } = $props();
+
+	let showSearch = $state(false);
+
+	function openSearch() {
+		showSearch = true;
+	}
+
+	function closeSearch() {
+		showSearch = false;
+	}
 
 	onMount(() => {
 		function handleKeydown(event: KeyboardEvent) {
@@ -12,6 +23,24 @@
 			if (event.ctrlKey && event.shiftKey && event.code === 'Digit4') {
 				event.preventDefault();
 				toggleCostMode();
+			}
+
+			// Cmd/Ctrl+K to open search
+			if ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.code === 'KeyK') {
+				event.preventDefault();
+				showSearch = true;
+			}
+
+			// "/" to open search when not typing in a field
+			if (event.key === '/' && !event.metaKey && !event.ctrlKey && !event.altKey) {
+				const target = event.target as HTMLElement | null;
+				const tag = target?.tagName;
+				const isEditable =
+					tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target?.isContentEditable;
+				if (!isEditable && !showSearch) {
+					event.preventDefault();
+					showSearch = true;
+				}
 			}
 		}
 
@@ -24,7 +53,36 @@
 	<meta property="og:url" content="https://thekrausshaus.com{$page.url.pathname}" />
 </svelte:head>
 
+<div class="absolute top-3 right-3 sm:top-4 sm:right-4 z-30">
+	<button
+		type="button"
+		class="cursor-pointer p-2 rounded-full bg-white/80 backdrop-blur-sm text-gray-500 hover:text-amber-600 hover:bg-white shadow-sm hover:shadow-md transition-all border border-gray-200/60"
+		on:click={openSearch}
+		aria-label="Open search"
+		aria-haspopup="dialog"
+		aria-expanded={showSearch}
+	>
+		<svg
+			class="h-5 w-5"
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="2"
+				d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z"
+			/>
+		</svg>
+	</button>
+</div>
+
 {@render children()}
+
+<SearchModal bind:isOpen={showSearch} onClose={closeSearch} />
 
 {#if $toastMessage}
 	<div

--- a/src/routes/bartenders/[slug]/+page.svelte
+++ b/src/routes/bartenders/[slug]/+page.svelte
@@ -7,7 +7,7 @@
 	import { fade, fly } from 'svelte/transition';
 
 	export let data: PageData;
-	const { bartender, cocktails } = data;
+	$: ({ bartender, cocktails } = data);
 </script>
 
 <svelte:head>

--- a/src/routes/cocktails/[slug]/+page.svelte
+++ b/src/routes/cocktails/[slug]/+page.svelte
@@ -14,11 +14,11 @@
 	import { costMode } from '$lib/stores/costMode';
 
 	export let data: PageData;
-	const { cocktail, onSummer, onWinter, onTiki, pathsContainingCocktail } = data;
-	const servingSentence = buildServingSentence(cocktail);
+	$: ({ cocktail, onSummer, onWinter, onTiki, pathsContainingCocktail } = data);
+	$: servingSentence = buildServingSentence(cocktail);
 
-	const onAnyMenu = onSummer || onWinter || onTiki;
-	const hasMenusOrPaths = onAnyMenu || pathsContainingCocktail.length > 0;
+	$: onAnyMenu = onSummer || onWinter || onTiki;
+	$: hasMenusOrPaths = onAnyMenu || pathsContainingCocktail.length > 0;
 
 	// Helper function to convert category label to URL-friendly key
 	// Handles special characters like & by converting to "and"

--- a/src/routes/menu/[slug]/+page.svelte
+++ b/src/routes/menu/[slug]/+page.svelte
@@ -7,7 +7,7 @@
 	import { fade, fly } from 'svelte/transition';
 
 	export let data: PageData;
-	const { menu } = data;
+	$: ({ menu } = data);
 </script>
 
 <svelte:head>

--- a/src/routes/parties/[slug]/+page.svelte
+++ b/src/routes/parties/[slug]/+page.svelte
@@ -6,7 +6,7 @@
 	import { fade, fly } from 'svelte/transition';
 
 	export let data: PageData;
-	const { party } = data;
+	$: ({ party } = data);
 
 	// Custom colors for the party theme
 	// TODO: Make this configurable per party if needed

--- a/src/routes/paths/[slug]/+page.svelte
+++ b/src/routes/paths/[slug]/+page.svelte
@@ -9,7 +9,7 @@
 	import { costMode } from '$lib/stores/costMode';
 
 	export let data: PageData;
-	const { path } = data;
+	$: ({ path } = data);
 
 	// Custom colors for the path theme
 	const pathColors = {

--- a/src/routes/recipes/[slug]/+page.svelte
+++ b/src/routes/recipes/[slug]/+page.svelte
@@ -7,7 +7,7 @@
 	import { fade, fly } from 'svelte/transition';
 
 	export let data: PageData;
-	const { recipe } = data;
+	$: ({ recipe } = data);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- Add Rum Runner and Tradewinds cocktails, plus a stone fruit liqueur recipe/ingredient (used in Missionary's Downfall)
- Tweak existing tiki drinks: split Mai Tai's orange curaçao between dry curaçao and Cointreau, swap Tia Mia's Cointreau for dry curaçao, swap Zombie for Rum Barrel on the tiki menu, reorder Royal and Warrior paths
- Add a global search modal with `Cmd+K` / `Ctrl+K` shortcut, backed by a new `all-searchable.ts` index across cocktails, recipes, ingredients, paths, and parties

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run check` passes
- [ ] `npm run test` passes
- [ ] Visit `/cocktails/rum-runner` and `/cocktails/tradewinds` — pages render
- [ ] Visit `/recipes/stone-fruit-liqueur` — recipe renders; Missionary's Downfall references it
- [ ] Verify Mai Tai and Tia Mia ingredient lists reflect the curaçao changes
- [ ] Verify the tiki menu shows Rum Barrel in place of Zombie
- [ ] Press `Cmd+K` (or `Ctrl+K`) anywhere — search modal opens, typing returns matches across cocktails/recipes/ingredients/paths/parties; `Esc` closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)