### PR TITLE
feat(data): reshuffle menus, paths, and ingredient naming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5701,21 +5701,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/src/lib/data/cocktail-paths/bard.ts
+++ b/src/lib/data/cocktail-paths/bard.ts
@@ -2,7 +2,7 @@ import type { CocktailPath } from '$lib/types/cocktail-path';
 import AMARETTO_SOUR from '../cocktails/amaretto-sour';
 import ESPRESSO_MARTINI from '../cocktails/espresso-martini';
 import MOJITO from '../cocktails/mojito';
-import SIDECAR from '../cocktails/sidecar';
+import SHARKS_TOOTH from '../cocktails/sharks-tooth';
 import SPRITZ from '../cocktails/spritz';
 
 export const BARD: CocktailPath = {
@@ -12,6 +12,6 @@ export const BARD: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/bard.jpeg',
 	description:
-		'The life of the party, one round at a time. This path opens with cool minty refreshment, shifts to breezy bubbles, refined citrus-brandy elegance, nutty sweetness, and a bold caffeinated finish. Nothing too challenging, nothing too obscure—just drinks that make everyone at the table happy.',
-	cocktails: [MOJITO, SPRITZ, SIDECAR, AMARETTO_SOUR, ESPRESSO_MARTINI]
+		'The life of the party, one round at a time. This path opens with cool minty refreshment, shifts to breezy bubbles, a fruity rum-and-pineapple cooler, nutty sweetness, and a bold caffeinated finish. Nothing too challenging, nothing too obscure—just drinks that make everyone at the table happy.',
+	cocktails: [MOJITO, SPRITZ, SHARKS_TOOTH, AMARETTO_SOUR, ESPRESSO_MARTINI]
 };

--- a/src/lib/data/cocktail-paths/hunter.ts
+++ b/src/lib/data/cocktail-paths/hunter.ts
@@ -1,9 +1,9 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
 import DAIQUIRI from '../cocktails/daiquiri';
 import DONGA_PUNCH from '../cocktails/donga-punch';
+import GILDA from '../cocktails/gilda';
 import HURRICANE from '../cocktails/hurricane';
 import IRON_RANGER from '../cocktails/iron-ranger';
-import MAI_TAI from '../cocktails/mai-tai';
 
 export const HUNTER: CocktailPath = {
 	title: 'Hunter',
@@ -12,6 +12,6 @@ export const HUNTER: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/hunter.jpeg',
 	description:
-		'Chase the sun through rum and tropical fruit. This path opens with clean citrus balance, builds into easy fruity sweetness, then layers in warm spice and unexpected spirit swaps before landing on layered, multi-rum complexity. The deeper you go, the more the tropics reveal.',
-	cocktails: [DAIQUIRI, HURRICANE, DONGA_PUNCH, IRON_RANGER, MAI_TAI]
+		'Chase the sun through tropical fruit and unexpected spirits. This path opens with spiced tequila, pineapple, and lime, settles into clean rum-and-citrus balance, builds into easy fruity sweetness, then layers in agricole funk and warm cinnamon before landing on a bourbon-and-falernum tiki swap. The deeper you go, the more the tropics reveal.',
+	cocktails: [GILDA, DAIQUIRI, HURRICANE, DONGA_PUNCH, IRON_RANGER]
 };

--- a/src/lib/data/cocktail-paths/warrior.ts
+++ b/src/lib/data/cocktail-paths/warrior.ts
@@ -1,5 +1,5 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
-import MINT_JULEP from '../cocktails/mint-julep';
+import MAI_TAI from '../cocktails/mai-tai';
 import NAVY_GROG from '../cocktails/navy-grog';
 import OLD_FASHIONED from '../cocktails/old-fashioned';
 import PENICILLIN from '../cocktails/penicillin';
@@ -12,6 +12,6 @@ export const WARRIOR: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/warrior.jpeg',
 	description:
-		'The spirit leads and everything else falls in line. This path opens on a sweetened bourbon foundation, escalates into three-rum tropical strength, cools through crushed-ice mint and bourbon, warms again with smoke and honeyed ginger, and arrives at austere, anise-tinged power. Each step strips away a little more, demanding respect for the base spirit.',
-	cocktails: [OLD_FASHIONED, MINT_JULEP, NAVY_GROG, PENICILLIN, SAZERAC]
+		'The spirit leads and everything else falls in line. This path opens on a sweetened bourbon foundation, sharpens into austere, anise-tinged rye and cognac, mellows through smoke and honeyed ginger, swings into honey-tempered high-proof rum, and lands on three-rum tropical strength. Each step demands a little more respect for the base spirit.',
+	cocktails: [OLD_FASHIONED, SAZERAC, PENICILLIN, NAVY_GROG, MAI_TAI]
 };

--- a/src/lib/data/cocktails/chocolate-covered-cherries.ts
+++ b/src/lib/data/cocktails/chocolate-covered-cherries.ts
@@ -8,7 +8,6 @@ import TELLERS from '$lib/data/bartenders/tellers';
 
 const CHOCOLATE_COVERED_CHERRIES: Cocktail = {
 	title: 'Chocolate Covered Cherries',
-	subtitle: "A creation from Teller's in OKC",
 	description:
 		'Bourbon, crème de cacao, cherry heering, cherry syrup, xocolatl bitters, maraschino cherry.',
 	imagePath:

--- a/src/lib/data/cocktails/merry-mule.ts
+++ b/src/lib/data/cocktails/merry-mule.ts
@@ -9,7 +9,7 @@ import AARON_KRAUSS from '$lib/data/bartenders/aaron-krauss';
 const MERRY_MULE: Cocktail = {
 	title: 'Merry Mule',
 	subtitle: "Served as the bride's drink at our wedding",
-	description: 'Vodka, cinnamon syrup, lime, ginger beer.',
+	description: 'Vodka, cinnamon, lime, ginger beer, apple.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/merry-mule.png',
 	thumbnailImagePath:

--- a/src/lib/data/ingredients/liqueurs.ts
+++ b/src/lib/data/ingredients/liqueurs.ts
@@ -102,7 +102,7 @@ const STONE_FRUIT_LIQUEUR: Ingredient = {
 	costPerOz: 11 / 25
 };
 const HOUSE_DARK_BERRY_CREME: Ingredient = {
-	title: 'Crème de Baies Noires',
+	title: 'Dark Berry Liqueur',
 	slug: 'house-dark-berry-creme',
 	recipe: HOUSE_DARK_BERRY_CREME_RECIPE,
 	costPerOz: 15 / 21.667

--- a/src/lib/data/recipes/house-dark-berry-creme.ts
+++ b/src/lib/data/recipes/house-dark-berry-creme.ts
@@ -1,7 +1,7 @@
 import type { Recipe } from '$lib/types/recipes';
 
 const HOUSE_DARK_BERRY_CREME: Recipe = {
-	name: 'Crème de Baies Noires',
+	name: 'Dark Berry Liqueur',
 	slug: 'house-dark-berry-creme',
 	description: 'A rich berry liqueur infused with vodka, lemon peel, and Ceylon black tea.',
 	ingredients: [

--- a/src/lib/data/summer-menu.ts
+++ b/src/lib/data/summer-menu.ts
@@ -6,37 +6,37 @@ import MARGARITA from '$lib/data/cocktails/margarita';
 import MICHELADA from '$lib/data/cocktails/michelada';
 import MOJITO from '$lib/data/cocktails/mojito';
 import MOONWELL from '$lib/data/cocktails/moonwell';
-import NEGRONI from '$lib/data/cocktails/negroni';
 import SPRITZ from '$lib/data/cocktails/spritz';
-import SPAGHETT from './cocktails/spaghett';
 import SURFER_ON_ACID from './cocktails/surfer-on-acid';
-import SLAP_N_PICKLE from './cocktails/slap-n-pickle';
 import KING_OF_KINGS from './cocktails/king-of-kings';
 import CAIPIRINHA from './cocktails/caipirinha';
 import DEAR_LUKEY from './cocktails/dear-lukey';
-import LOGGY_CAB from './cocktails/loggy-cab';
+import GIN_BASIL_SMASH from './cocktails/gin-basil-smash';
+import MINT_JULEP from './cocktails/mint-julep';
+import RUM_RUNNER from './cocktails/rum-runner';
+import PAPER_PLANE from './cocktails/paper-plane';
 
-export const featuredDrinks: Cocktail[] = [GILDED_ROSE, LOGGY_CAB];
+export const featuredDrinks: Cocktail[] = [GILDED_ROSE, MOONWELL];
 
 export const categories: Category[] = [
 	{
 		title: "Mommy's Drinks",
 		bgColors: sectionColors.mommy,
-		cocktails: [MOJITO, MARGARITA, MOONWELL]
+		cocktails: [MOJITO, MARGARITA, GIN_BASIL_SMASH]
 	},
 	{
 		title: "Daddy's Drinks",
 		bgColors: sectionColors.daddy,
-		cocktails: [MICHELADA, NEGRONI, SURFER_ON_ACID]
+		cocktails: [MICHELADA, MINT_JULEP, SURFER_ON_ACID]
 	},
 	{
 		title: "Cyrus' Drinks",
 		bgColors: sectionColors.cyrus,
-		cocktails: [KING_OF_KINGS, CAIPIRINHA, SLAP_N_PICKLE]
+		cocktails: [KING_OF_KINGS, CAIPIRINHA, RUM_RUNNER]
 	},
 	{
 		title: "Lucas' Drinks",
 		bgColors: sectionColors.lucas,
-		cocktails: [SPRITZ, DEAR_LUKEY, SPAGHETT]
+		cocktails: [SPRITZ, DEAR_LUKEY, PAPER_PLANE]
 	}
 ];

--- a/src/lib/data/tiki-menu.ts
+++ b/src/lib/data/tiki-menu.ts
@@ -12,7 +12,7 @@ import PAINKILLER from '$lib/data/cocktails/painkiller';
 import DESERT_DREAMS from '$lib/data/cocktails/desert-dreams';
 import SATURN from '$lib/data/cocktails/saturn';
 import SINGAPORE_SLING from '$lib/data/cocktails/singapore-sling';
-import RUM_BARREL from '$lib/data/cocktails/rum-barrel';
+import ZOMBIE from '$lib/data/cocktails/zombie';
 import THREE_DOTS_AND_A_DASH from '$lib/data/cocktails/three-dots-and-a-dash';
 import LOST_LAKE from '$lib/data/cocktails/lost-lake';
 import NAVY_GROG from '$lib/data/cocktails/navy-grog';
@@ -38,7 +38,7 @@ export const categories: Category[] = [
 			tertiary: '#fdf2f8',
 			variationText: '#581c87'
 		},
-		cocktails: [NAVY_GROG, LOST_LAKE, MAI_TAI, THREE_DOTS_AND_A_DASH, COBRAS_FANG, RUM_BARREL]
+		cocktails: [NAVY_GROG, LOST_LAKE, MAI_TAI, THREE_DOTS_AND_A_DASH, COBRAS_FANG, ZOMBIE]
 	},
 	{
 		title: 'Not Just Rum',

--- a/src/lib/data/winter-menu.ts
+++ b/src/lib/data/winter-menu.ts
@@ -12,17 +12,17 @@ import OAXACA_OLD_FASHIONED from '$lib/data/cocktails/oaxaca-old-fashioned';
 import MANHATTAN from '$lib/data/cocktails/manhattan';
 import ESPRESSO_MARTINI from '$lib/data/cocktails/espresso-martini';
 import CHOCOLATE_COVERED_CHERRIES from '$lib/data/cocktails/chocolate-covered-cherries';
-import RATTLE_SKULL from './cocktails/rattle-skull';
-import PAPER_PLANE from './cocktails/paper-plane';
+import NEGRONI from './cocktails/negroni';
+import SLAP_N_PICKLE from './cocktails/slap-n-pickle';
 import JACK_ROSE from './cocktails/jack-rose';
 
-export const featuredDrinks: Cocktail[] = [CARAMEL_APPLE_SPICE, CHOCOLATE_COVERED_CHERRIES];
+export const featuredDrinks: Cocktail[] = [CARAMEL_APPLE_SPICE, MERRY_MULE];
 
 export const categories: Category[] = [
 	{
 		title: "Mommy's Drinks",
 		bgColors: sectionColors.mommy,
-		cocktails: [HOT_TODDY, MERRY_MULE, PENICILLIN]
+		cocktails: [HOT_TODDY, CHOCOLATE_COVERED_CHERRIES, PENICILLIN]
 	},
 	{
 		title: "Daddy's Drinks",
@@ -32,11 +32,11 @@ export const categories: Category[] = [
 	{
 		title: "Cyrus' Drinks",
 		bgColors: sectionColors.cyrus,
-		cocktails: [JACK_ROSE, RATTLE_SKULL, OAXACA_OLD_FASHIONED]
+		cocktails: [JACK_ROSE, SLAP_N_PICKLE, OAXACA_OLD_FASHIONED]
 	},
 	{
 		title: "Lucas' Drinks",
 		bgColors: sectionColors.lucas,
-		cocktails: [MANHATTAN, PAPER_PLANE, ESPRESSO_MARTINI]
+		cocktails: [MANHATTAN, NEGRONI, ESPRESSO_MARTINI]
 	}
 ];


### PR DESCRIPTION
## Summary
- Swapped cocktails across the **bard**, **hunter**, and **warrior** cocktail paths and rewrote their descriptions to match the new lineups
- Refreshed the **summer** and **winter** seasonal menus (category lineups + featured drinks)
- Swapped Rum Barrel for **Zombie** on the **tiki** menu
- Renamed the house dark berry liqueur from "Crème de Baies Noires" to **"Dark Berry Liqueur"** (ingredient + recipe)
- Tidied copy: removed the Chocolate Covered Cherries subtitle and updated the Merry Mule description
- Dropped a stale `yaml` entry from `package-lock.json`

## Test plan
- [ ] `npm run check` passes (no broken imports)
- [ ] `npm run lint` passes
- [ ] Spot-check the affected menu and path pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)