### PR TITLE
feat(data): reshuffle menus/paths and bring back the Grasshopper

### DIFF
--- a/src/lib/data/all-cocktails.ts
+++ b/src/lib/data/all-cocktails.ts
@@ -45,6 +45,7 @@ import GIN_AND_TONIC from '$lib/data/cocktails/gin-and-tonic';
 import GIN_BASIL_SMASH from '$lib/data/cocktails/gin-basil-smash';
 import GLUHWEIN from '$lib/data/cocktails/gluhwein';
 import GODFATHER from '$lib/data/cocktails/godfather';
+import GRASSHOPPER from '$lib/data/cocktails/grasshopper';
 import HIGHLAND_COFFEE from '$lib/data/cocktails/highland-coffee';
 import HOT_TODDY from '$lib/data/cocktails/hot-toddy';
 import HUGO_SPRITZ from '$lib/data/cocktails/hugo-spritz';
@@ -164,6 +165,7 @@ export const allCocktails: Cocktail[] = [
 	GIN_BASIL_SMASH,
 	GLUHWEIN,
 	GODFATHER,
+	GRASSHOPPER,
 	HIGHLAND_COFFEE,
 	HOT_TODDY,
 	HUGO_SPRITZ,

--- a/src/lib/data/cocktails/grasshopper.ts
+++ b/src/lib/data/cocktails/grasshopper.ts
@@ -1,0 +1,50 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+
+const GRASSHOPPER: Cocktail = {
+	title: 'Grasshopper',
+	description: 'Vodka, mint syrup, crème de cacao, heavy cream.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/grasshopper.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/grasshopper.png',
+	slug: 'grasshopper',
+	method: CocktailMethod.Shaken,
+	servedIn: ServedIn.CoupeGlass,
+	ice: Ice.None,
+	hasStraw: false,
+	ingredients: [
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.BaseSpirits.MONOPOLOWA
+		},
+		{
+			amount: '.75oz',
+			ingredient: Ingredients.Syrups.MINT_SYRUP
+		},
+		{
+			amount: '.75oz',
+			ingredient: Ingredients.Liqueurs.CREME_DE_CACAO
+		},
+		{
+			amount: '1oz',
+			ingredient: Ingredients.Other.HEAVY_CREAM
+		}
+	],
+	notes: 'Shake with ice and strain into a chilled coupe glass.',
+	tags: [
+		Tags.BaseAlcohol.VODKA,
+		Tags.FlavorProfile.CREAMY,
+		Tags.FlavorProfile.HERBAL,
+		Tags.Technique.SHAKEN,
+		Tags.Origin.CLASSIC,
+		Tags.ServedIn.COUPE_GLASS,
+		Tags.AlcoholLevel.LOW
+	]
+};
+
+export default GRASSHOPPER;


### PR DESCRIPTION
## Summary

- **Grasshopper returns** — recreated the cocktail, reformulated to use vodka + mint syrup in place of the removed crème de menthe (`.5oz` vodka, `.75oz` mint syrup, `.75oz` crème de cacao, `1oz` heavy cream). Reuses existing ingredients/recipe; no new ingredient or recipe files.
- **Path reshuffle** — swapped cocktails across the bard, hunter, and warrior paths with updated descriptions.
- **Seasonal menus** — refreshed the summer and winter menu lineups and featured drinks.
- **Tiki menu** — swapped Rum Barrel for Zombie.
- **Naming/copy** — renamed the house dark berry liqueur to "Dark Berry Liqueur"; tidied subtitle/description copy for Chocolate Covered Cherries and Merry Mule.

## Notes

`npm run check` reports pre-existing errors only (in `spirit-dilution-calculator` and `parties` routes) — none touch these changes. Prettier and ESLint pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)