### PR TITLE
feat(cocktails): add Lavender Liqueur, Daiquiri +Lavender variant, and Night Flight

### DIFF
--- a/src/lib/data/all-cocktails.ts
+++ b/src/lib/data/all-cocktails.ts
@@ -76,6 +76,7 @@ import NAKED_AND_FAMOUS from '$lib/data/cocktails/naked-and-famous';
 import NAVY_GROG from '$lib/data/cocktails/navy-grog';
 import NEGRONI from '$lib/data/cocktails/negroni';
 import NEGRONI_BIANCO_BERGAMOTTO from '$lib/data/cocktails/negroni-bianco-bergamotto';
+import NIGHT_FLIGHT from '$lib/data/cocktails/night-flight';
 import NORWEIGAN_PARALYSIS from '$lib/data/cocktails/norwegian-paralysis';
 import OAXACA_OLD_FASHIONED from '$lib/data/cocktails/oaxaca-old-fashioned';
 import OLD_FASHIONED from '$lib/data/cocktails/old-fashioned';
@@ -196,6 +197,7 @@ export const allCocktails: Cocktail[] = [
 	NAVY_GROG,
 	NEGRONI,
 	NEGRONI_BIANCO_BERGAMOTTO,
+	NIGHT_FLIGHT,
 	NORWEIGAN_PARALYSIS,
 	OAXACA_OLD_FASHIONED,
 	OLD_FASHIONED,

--- a/src/lib/data/all-recipes.ts
+++ b/src/lib/data/all-recipes.ts
@@ -23,6 +23,7 @@ import DRY_CURACAO from '$lib/data/recipes/dry-curacao';
 import FALERNUM from '$lib/data/recipes/falernum';
 import HOUSE_DARK_BERRY_CREME from '$lib/data/recipes/house-dark-berry-creme';
 import JALAPENO_TEQUILA from '$lib/data/recipes/jalapeno-tequila';
+import LAVENDER_LIQUEUR from '$lib/data/recipes/lavender-liqueur';
 import LIMONCELLO from '$lib/data/recipes/limoncello';
 import PEPPERMINT_VODKA from '$lib/data/recipes/peppermint-vodka';
 import PERSIAN_SPICE_LIQUEUR from '$lib/data/recipes/persian-spice-liqueur';
@@ -55,6 +56,7 @@ export const infusions: Recipe[] = [
 	FALERNUM,
 	HOUSE_DARK_BERRY_CREME,
 	JALAPENO_TEQUILA,
+	LAVENDER_LIQUEUR,
 	LIMONCELLO,
 	PEPPERMINT_VODKA,
 	PERSIAN_SPICE_LIQUEUR,

--- a/src/lib/data/cocktails/daiquiri.ts
+++ b/src/lib/data/cocktails/daiquiri.ts
@@ -45,6 +45,20 @@ const DAIQUIRI: Cocktail = {
 				}
 			],
 			images: []
+		},
+		{
+			name: '+Lavender',
+			ingredients: [
+				{
+					label: 'Swap 1oz of Probitas with 1oz Lavender Liqueur.',
+					ingredient: Ingredients.Liqueurs.LAVENDER_LIQUEUR
+				},
+				{
+					label: 'Reduce rich simple syrup to .25oz.',
+					ingredient: Ingredients.Syrups.RICH_SIMPLE_SYRUP
+				}
+			],
+			images: []
 		}
 	],
 	tags: [

--- a/src/lib/data/cocktails/night-flight.ts
+++ b/src/lib/data/cocktails/night-flight.ts
@@ -1,0 +1,55 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+import AARON_KRAUSS from '$lib/data/bartenders/aaron-krauss';
+
+const NIGHT_FLIGHT: Cocktail = {
+	title: 'Night Flight',
+	description: 'Gin, lemon, maraschino, lavender, and dark berry liqueur.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/night-flight.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/night-flight.png',
+	slug: 'night-flight',
+	createdBy: AARON_KRAUSS,
+	method: CocktailMethod.Shaken,
+	servedIn: ServedIn.CoupeGlass,
+	ice: Ice.None,
+	hasStraw: false,
+	ingredients: [
+		{
+			amount: '2oz',
+			ingredient: Ingredients.BaseSpirits.FORDS
+		},
+		{
+			amount: '.75oz',
+			ingredient: Ingredients.Citrus.LEMON
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.Liqueurs.MARASCHINO_LIQUEUER
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.Liqueurs.LAVENDER_LIQUEUR
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.Liqueurs.HOUSE_DARK_BERRY_CREME
+		}
+	],
+	tags: [
+		Tags.BaseAlcohol.GIN,
+		Tags.FlavorProfile.CITRUS,
+		Tags.FlavorProfile.FRUITY,
+		Tags.Technique.SHAKEN,
+		Tags.Style.SOUR,
+		Tags.Origin.ORIGINAL,
+		Tags.ServedIn.COUPE_GLASS
+	]
+};
+
+export default NIGHT_FLIGHT;

--- a/src/lib/data/ingredients/liqueurs.ts
+++ b/src/lib/data/ingredients/liqueurs.ts
@@ -7,6 +7,7 @@ import PERSIAN_SPICE_LIQUEUR_RECIPE from '$lib/data/recipes/persian-spice-liqueu
 import DRY_CURACAO_RECIPE from '$lib/data/recipes/dry-curacao';
 import HOUSE_DARK_BERRY_CREME_RECIPE from '$lib/data/recipes/house-dark-berry-creme';
 import STONE_FRUIT_LIQUEUR_RECIPE from '$lib/data/recipes/stone-fruit-liqueur';
+import LAVENDER_LIQUEUR_RECIPE from '$lib/data/recipes/lavender-liqueur';
 
 // Amaro
 const AMARO_LUCANO: Ingredient = {
@@ -158,6 +159,12 @@ const ITALICUS: Ingredient = {
 	slug: 'italicus',
 	costPerOz: 32 / 25
 };
+const LAVENDER_LIQUEUR: Ingredient = {
+	title: 'Lavender Liqueur',
+	slug: 'lavender-liqueur',
+	costPerOz: 1.5 / 7,
+	recipe: LAVENDER_LIQUEUR_RECIPE
+};
 const MR_BLACK: Ingredient = {
 	title: 'Mr. Black',
 	slug: 'mr-black',
@@ -208,6 +215,7 @@ export const LIQUEURS: IngredientCategory = {
 				EGGNOG,
 				ELDERFLOWER_LIQUEUR,
 				ITALICUS,
+				LAVENDER_LIQUEUR,
 				MR_BLACK,
 				PERSIAN_SPICE_LIQUEUR
 			]
@@ -250,6 +258,7 @@ export const INGREDIENTS = {
 	EGGNOG,
 	ELDERFLOWER_LIQUEUR,
 	ITALICUS,
+	LAVENDER_LIQUEUR,
 	MR_BLACK,
 	PERSIAN_SPICE_LIQUEUR
 };

--- a/src/lib/data/recipes/lavender-liqueur.ts
+++ b/src/lib/data/recipes/lavender-liqueur.ts
@@ -1,0 +1,19 @@
+import type { Recipe } from '$lib/types/recipes';
+
+const LAVENDER_LIQUEUR: Recipe = {
+	name: 'Lavender Liqueur',
+	slug: 'lavender-liqueur',
+	description: 'A floral liqueur made by infusing lavender into grain alcohol.',
+	ingredients: [
+		'2oz Everclear (190 proof)',
+		'3oz Water',
+		'1 tsp dried culinary lavender petals (or 1 tbsp fresh)',
+		'2oz Simple Syrup (1:1)',
+		'Optional: small strip lemon peel (no white pith)'
+	],
+	instructions:
+		'Steep everything but the syrup for 12 hours. Strain out the solids, then add the syrup.',
+	notes: 'Makes ~7oz at 27% ABV.'
+};
+
+export default LAVENDER_LIQUEUR;


### PR DESCRIPTION
## Summary

- **Lavender Liqueur** added as both a recipe (Everclear + lavender infusion, ~7oz at 27% ABV) and an ingredient (Liqueurs → Floral, Coffee & Specialty).
- **Daiquiri +Lavender variant** — swaps 1oz of rum for 1oz Lavender Liqueur and reduces rich simple syrup to .25oz.
- **Night Flight** — a new shaken gin sour served up in a coupe (gin, lemon, maraschino, lavender, dark berry), created by Aaron Krauss.

## Notes

- Night Flight uses the standard CDN image path convention; image assets still need to be uploaded.
- `svelte-check` passes clean for all changed files (pre-existing unrelated route-typing errors remain in `.svelte` files); lint + Prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)