### PR TITLE
feat(cocktails): add Rudolph's Nose, switch house gin, rework paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,5 +93,5 @@ Run: `npm run test`
 ## Pull Requests
 
 - Use the `gh` CLI tool to create pull requests.
-- Authenticate by reading the GitHub token from the `.env` file and passing it via the `GH_TOKEN` environment variable (e.g., `GH_TOKEN=$(grep GITHUB_TOKEN .env | cut -d '=' -f2) gh pr create ...`).
+- Authenticate by reading the `GH_TOKEN` value from the `.env` file and exporting it as the `GH_TOKEN` environment variable (e.g., `GH_TOKEN=$(grep '^GH_TOKEN=' .env | cut -d '=' -f2) gh pr create ...`).
 - Always create pull requests as **drafts** (`--draft` flag).

--- a/src/lib/data/all-cocktails.ts
+++ b/src/lib/data/all-cocktails.ts
@@ -91,6 +91,7 @@ import PORT_LIGHT from '$lib/data/cocktails/port-light';
 import RADLER from '$lib/data/cocktails/radler';
 import RAMOS_GIN_FIZZ from '$lib/data/cocktails/ramos-gin-fizz';
 import RATTLE_SKULL from '$lib/data/cocktails/rattle-skull';
+import RUDOLPHS_NOSE from '$lib/data/cocktails/rudolphs-nose';
 import RUM_BARREL from '$lib/data/cocktails/rum-barrel';
 import RUM_RUNNER from '$lib/data/cocktails/rum-runner';
 import RUSSIAN_SPRING_PUNCH from '$lib/data/cocktails/russian-spring-punch';
@@ -212,6 +213,7 @@ export const allCocktails: Cocktail[] = [
 	RADLER,
 	RAMOS_GIN_FIZZ,
 	RATTLE_SKULL,
+	RUDOLPHS_NOSE,
 	RUM_BARREL,
 	RUM_RUNNER,
 	RUSSIAN_SPRING_PUNCH,

--- a/src/lib/data/cocktail-paths/bard.ts
+++ b/src/lib/data/cocktail-paths/bard.ts
@@ -2,7 +2,7 @@ import type { CocktailPath } from '$lib/types/cocktail-path';
 import AMARETTO_SOUR from '../cocktails/amaretto-sour';
 import ESPRESSO_MARTINI from '../cocktails/espresso-martini';
 import MOJITO from '../cocktails/mojito';
-import SHARKS_TOOTH from '../cocktails/sharks-tooth';
+import PAINKILLER from '../cocktails/painkiller';
 import SPRITZ from '../cocktails/spritz';
 
 export const BARD: CocktailPath = {
@@ -12,6 +12,6 @@ export const BARD: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/bard.jpeg',
 	description:
-		'The life of the party, one round at a time. This path opens with cool minty refreshment, shifts to breezy bubbles, a fruity rum-and-pineapple cooler, nutty sweetness, and a bold caffeinated finish. Nothing too challenging, nothing too obscure—just drinks that make everyone at the table happy.',
-	cocktails: [MOJITO, SPRITZ, SHARKS_TOOTH, AMARETTO_SOUR, ESPRESSO_MARTINI]
+		'The life of the party, one round at a time. This path opens with cool minty refreshment, shifts to breezy bubbles, then creamy coconut and pineapple, nutty sweetness, and a bold caffeinated finish. Nothing too challenging, nothing too obscure—just drinks that make everyone at the table happy.',
+	cocktails: [MOJITO, SPRITZ, PAINKILLER, AMARETTO_SOUR, ESPRESSO_MARTINI]
 };

--- a/src/lib/data/cocktail-paths/royal.ts
+++ b/src/lib/data/cocktail-paths/royal.ts
@@ -1,9 +1,9 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
-import KING_OF_KINGS from '../cocktails/king-of-kings';
 import CHOCOLATE_COVERED_CHERRIES from '../cocktails/chocolate-covered-cherries';
-import SINGAPORE_SLING from '../cocktails/singapore-sling';
-import PAINKILLER from '../cocktails/painkiller';
+import FRENCH_75 from '../cocktails/french-75';
+import KING_OF_KINGS from '../cocktails/king-of-kings';
 import RAMOS_GIN_FIZZ from '../cocktails/ramos-gin-fizz';
+import SINGAPORE_SLING from '../cocktails/singapore-sling';
 
 export const ROYAL: CocktailPath = {
 	title: 'Royal',
@@ -12,12 +12,6 @@ export const ROYAL: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/royal.jpeg',
 	description:
-		'Every sip should feel like an indulgence. This path opens with a lavish cascade of fruit and liqueur, melts into creamy tropical bliss, deepens through rich multi-spirit warmth and a dessert you can drink, then finishes with a velvety, cream-topped crown jewel. These are drinks that reward you for going all in.',
-	cocktails: [
-		KING_OF_KINGS,
-		SINGAPORE_SLING,
-		PAINKILLER,
-		CHOCOLATE_COVERED_CHERRIES,
-		RAMOS_GIN_FIZZ
-	]
+		'Every sip should feel like an indulgence. This path opens on a champagne toast, escalates into a lavish multi-spirit tiki blend, moves through a cascade of fruit and liqueur, then dips into a dessert you can drink before finishing with a velvety, cream-topped crown jewel. These are drinks that reward you for going all in.',
+	cocktails: [FRENCH_75, KING_OF_KINGS, SINGAPORE_SLING, CHOCOLATE_COVERED_CHERRIES, RAMOS_GIN_FIZZ]
 };

--- a/src/lib/data/cocktails/alaska.ts
+++ b/src/lib/data/cocktails/alaska.ts
@@ -20,7 +20,7 @@ const ALASKA: Cocktail = {
 	ingredients: [
 		{
 			amount: '2oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.75oz',

--- a/src/lib/data/cocktails/bramble.ts
+++ b/src/lib/data/cocktails/bramble.ts
@@ -22,7 +22,7 @@ const BRAMBLE: Cocktail = {
 	ingredients: [
 		{
 			amount: '2oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.5oz',

--- a/src/lib/data/cocktails/count-mast.ts
+++ b/src/lib/data/cocktails/count-mast.ts
@@ -20,7 +20,7 @@ const COUNT_MAST: Cocktail = {
 	ingredients: [
 		{
 			amount: '1oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '1oz',

--- a/src/lib/data/cocktails/forest-spirit.ts
+++ b/src/lib/data/cocktails/forest-spirit.ts
@@ -23,7 +23,7 @@ const FOREST_SPIRIT: Cocktail = {
 	ingredients: [
 		{
 			amount: '1.5oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.5oz',

--- a/src/lib/data/cocktails/french-75.ts
+++ b/src/lib/data/cocktails/french-75.ts
@@ -20,7 +20,7 @@ const FRENCH_75: Cocktail = {
 	ingredients: [
 		{
 			amount: '1oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.5oz',

--- a/src/lib/data/cocktails/gin-and-tonic.ts
+++ b/src/lib/data/cocktails/gin-and-tonic.ts
@@ -20,7 +20,7 @@ const GIN_AND_TONIC: Cocktail = {
 	ingredients: [
 		{
 			amount: '1.5oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '4oz',

--- a/src/lib/data/cocktails/gin-basil-smash.ts
+++ b/src/lib/data/cocktails/gin-basil-smash.ts
@@ -22,7 +22,7 @@ const GIN_BASIL_SMASH: Cocktail = {
 	ingredients: [
 		{
 			amount: '2oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.75oz',

--- a/src/lib/data/cocktails/last-word.ts
+++ b/src/lib/data/cocktails/last-word.ts
@@ -20,7 +20,7 @@ const LAST_WORD: Cocktail = {
 	ingredients: [
 		{
 			amount: '.75oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.75oz',

--- a/src/lib/data/cocktails/loggy-cab.ts
+++ b/src/lib/data/cocktails/loggy-cab.ts
@@ -22,7 +22,7 @@ const LOGGY_CAB: Cocktail = {
 	ingredients: [
 		{
 			amount: '2oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.75oz',

--- a/src/lib/data/cocktails/martini.ts
+++ b/src/lib/data/cocktails/martini.ts
@@ -20,7 +20,7 @@ const MARTINI: Cocktail = {
 	ingredients: [
 		{
 			amount: '2oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '1oz',

--- a/src/lib/data/cocktails/moonwell.ts
+++ b/src/lib/data/cocktails/moonwell.ts
@@ -70,7 +70,7 @@ const MOONWELL: Cocktail = {
 			ingredients: [
 				{
 					label: 'Sub gin for rum.',
-					ingredient: Ingredients.BaseSpirits.FORDS
+					ingredient: Ingredients.BaseSpirits.TANQUERAY
 				}
 			],
 			images: ['/images/wow/race_nightelf_male.jpg', '/images/wow/class_hunter.jpg']

--- a/src/lib/data/cocktails/negroni-bianco-bergamotto.ts
+++ b/src/lib/data/cocktails/negroni-bianco-bergamotto.ts
@@ -20,7 +20,7 @@ const NEGRONI_BIANCO_BERGAMOTTO: Cocktail = {
 	ingredients: [
 		{
 			amount: '1oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '1oz',

--- a/src/lib/data/cocktails/negroni.ts
+++ b/src/lib/data/cocktails/negroni.ts
@@ -20,7 +20,7 @@ const NEGRONI: Cocktail = {
 	ingredients: [
 		{
 			amount: '1oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '1oz',

--- a/src/lib/data/cocktails/night-flight.ts
+++ b/src/lib/data/cocktails/night-flight.ts
@@ -21,30 +21,32 @@ const NIGHT_FLIGHT: Cocktail = {
 	hasStraw: false,
 	ingredients: [
 		{
-			amount: '2oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			amount: '1.5oz',
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.75oz',
-			ingredient: Ingredients.Citrus.LEMON
-		},
-		{
-			amount: '.25oz',
-			ingredient: Ingredients.Liqueurs.MARASCHINO_LIQUEUER
-		},
-		{
-			amount: '.25oz',
 			ingredient: Ingredients.Liqueurs.LAVENDER_LIQUEUR
 		},
 		{
-			amount: '.25oz',
+			amount: '.5oz',
 			ingredient: Ingredients.Liqueurs.HOUSE_DARK_BERRY_CREME
-		}
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Citrus.LEMON
+		},
+		{
+			amount: '1 dash',
+			ingredient: Ingredients.Bitters.ORANGE
+		},
+		'Garnish: Lavender sprig'
 	],
 	tags: [
 		Tags.BaseAlcohol.GIN,
 		Tags.FlavorProfile.CITRUS,
 		Tags.FlavorProfile.FRUITY,
+		Tags.FlavorProfile.HERBAL,
 		Tags.Technique.SHAKEN,
 		Tags.Style.SOUR,
 		Tags.Origin.ORIGINAL,

--- a/src/lib/data/cocktails/ramos-gin-fizz.ts
+++ b/src/lib/data/cocktails/ramos-gin-fizz.ts
@@ -23,7 +23,7 @@ const RAMOS_GIN_FIZZ: Cocktail = {
 	ingredients: [
 		{
 			amount: '2oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.5oz',

--- a/src/lib/data/cocktails/rudolphs-nose.ts
+++ b/src/lib/data/cocktails/rudolphs-nose.ts
@@ -1,0 +1,68 @@
+import { CocktailMethod } from '$lib/enums/methods';
+import { ServedIn } from '$lib/enums/served-in';
+import type { Cocktail } from '$lib/types/cocktails';
+import { Ingredients } from '../all-ingredients';
+import { Tags } from '../all-tags';
+import { Ice } from '$lib/enums/ice';
+
+const RUDOLPHS_NOSE: Cocktail = {
+	title: "Rudolph's Nose",
+	description: 'Light rum, apple brandy, fassionola, falernum, pineapple, lime, angostura bitters.',
+	imagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/rudolphs-nose.png',
+	thumbnailImagePath:
+		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/rudolphs-nose.png',
+	slug: 'rudolphs-nose',
+	method: CocktailMethod.Shaken,
+	servedIn: ServedIn.CoupeGlass,
+	ice: Ice.None,
+	hasStraw: false,
+	ingredients: [
+		{
+			amount: '1oz',
+			ingredient: Ingredients.BaseSpirits.PLANTERAY_3_STARS
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.BaseSpirits.LAIRDS_BIB
+		},
+		{
+			amount: '1oz',
+			ingredient: Ingredients.Syrups.FASSIONOLA
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.Liqueurs.FALERNUM
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Citrus.PINEAPPLE
+		},
+		{
+			amount: '.5oz',
+			ingredient: Ingredients.Citrus.LIME
+		},
+		{
+			amount: '2 dashes',
+			ingredient: Ingredients.Bitters.ANGOSTURA
+		},
+		{
+			label: 'Garnish: Maraschino Cherry',
+			ingredient: Ingredients.Other.MARASCHINO_CHERRY
+		}
+	],
+	tags: [
+		Tags.BaseAlcohol.RUM,
+		Tags.BaseAlcohol.BRANDY,
+		Tags.FlavorProfile.FRUITY,
+		Tags.FlavorProfile.CITRUS,
+		Tags.FlavorProfile.SPICED,
+		Tags.Technique.SHAKEN,
+		Tags.Style.SOUR,
+		Tags.Style.TIKI,
+		Tags.Origin.ORIGINAL,
+		Tags.ServedIn.COUPE_GLASS
+	]
+};
+
+export default RUDOLPHS_NOSE;

--- a/src/lib/data/cocktails/rudolphs-nose.ts
+++ b/src/lib/data/cocktails/rudolphs-nose.ts
@@ -4,6 +4,7 @@ import type { Cocktail } from '$lib/types/cocktails';
 import { Ingredients } from '../all-ingredients';
 import { Tags } from '../all-tags';
 import { Ice } from '$lib/enums/ice';
+import AARON_KRAUSS from '$lib/data/bartenders/aaron-krauss';
 
 const RUDOLPHS_NOSE: Cocktail = {
 	title: "Rudolph's Nose",
@@ -13,6 +14,7 @@ const RUDOLPHS_NOSE: Cocktail = {
 	thumbnailImagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/thumbnail/rudolphs-nose.png',
 	slug: 'rudolphs-nose',
+	createdBy: AARON_KRAUSS,
 	method: CocktailMethod.Shaken,
 	servedIn: ServedIn.CoupeGlass,
 	ice: Ice.None,

--- a/src/lib/data/cocktails/saturn.ts
+++ b/src/lib/data/cocktails/saturn.ts
@@ -22,7 +22,7 @@ const SATURN: Cocktail = {
 	ingredients: [
 		{
 			amount: '1.5oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '.5oz',

--- a/src/lib/data/cocktails/singapore-sling.ts
+++ b/src/lib/data/cocktails/singapore-sling.ts
@@ -23,7 +23,7 @@ const SINGAPORE_SLING: Cocktail = {
 	ingredients: [
 		{
 			amount: '1oz',
-			ingredient: Ingredients.BaseSpirits.FORDS
+			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
 			amount: '2 tsp',

--- a/src/lib/data/ingredients/base-spirits.ts
+++ b/src/lib/data/ingredients/base-spirits.ts
@@ -159,11 +159,11 @@ const DEL_MAGUY_VIDA: Ingredient = {
 };
 
 // Gin
-const FORDS: Ingredient = {
-	title: 'Fords',
-	slug: 'fords',
+const TANQUERAY: Ingredient = {
+	title: 'Tanqueray',
+	slug: 'tanqueray',
 	group: 'London Dry Gin',
-	costPerOz: 28 / 25
+	costPerOz: 42 / 59
 };
 
 // Neutral Spirits
@@ -239,7 +239,7 @@ export const BASE_SPIRITS: IngredientCategory = {
 		},
 		{
 			label: 'Gin',
-			ingredients: [FORDS]
+			ingredients: [TANQUERAY]
 		},
 		{
 			label: 'Neutral Spirits',
@@ -282,7 +282,7 @@ export const INGREDIENTS = {
 	DEL_MAGUY_VIDA,
 
 	// Gin
-	FORDS,
+	TANQUERAY,
 
 	// Neutral Spirits
 	MONOPOLOWA,

--- a/src/lib/data/ingredients/other.ts
+++ b/src/lib/data/ingredients/other.ts
@@ -22,7 +22,7 @@ const CUCUMBER: Ingredient = {
 const EGG: Ingredient = {
 	title: 'Egg',
 	slug: 'egg',
-	costPerOz: 0.3
+	costPerOz: 5 / 12
 };
 const HEAVY_CREAM: Ingredient = {
 	title: 'Heavy Cream',

--- a/src/lib/data/winter-menu.ts
+++ b/src/lib/data/winter-menu.ts
@@ -14,15 +14,15 @@ import ESPRESSO_MARTINI from '$lib/data/cocktails/espresso-martini';
 import CHOCOLATE_COVERED_CHERRIES from '$lib/data/cocktails/chocolate-covered-cherries';
 import NEGRONI from './cocktails/negroni';
 import SLAP_N_PICKLE from './cocktails/slap-n-pickle';
-import JACK_ROSE from './cocktails/jack-rose';
+import RUDOLPHS_NOSE from './cocktails/rudolphs-nose';
 
-export const featuredDrinks: Cocktail[] = [CARAMEL_APPLE_SPICE, MERRY_MULE];
+export const featuredDrinks: Cocktail[] = [CARAMEL_APPLE_SPICE, RUDOLPHS_NOSE];
 
 export const categories: Category[] = [
 	{
 		title: "Mommy's Drinks",
 		bgColors: sectionColors.mommy,
-		cocktails: [HOT_TODDY, CHOCOLATE_COVERED_CHERRIES, PENICILLIN]
+		cocktails: [HOT_TODDY, CHOCOLATE_COVERED_CHERRIES, MERRY_MULE]
 	},
 	{
 		title: "Daddy's Drinks",
@@ -32,7 +32,7 @@ export const categories: Category[] = [
 	{
 		title: "Cyrus' Drinks",
 		bgColors: sectionColors.cyrus,
-		cocktails: [JACK_ROSE, SLAP_N_PICKLE, OAXACA_OLD_FASHIONED]
+		cocktails: [PENICILLIN, SLAP_N_PICKLE, OAXACA_OLD_FASHIONED]
 	},
 	{
 		title: "Lucas' Drinks",


### PR DESCRIPTION
## Summary

- **New cocktail: Rudolph's Nose** — added `src/lib/data/cocktails/rudolphs-nose.ts`, registered in `all-cocktails.ts`, credited to Aaron Krauss, and promoted to a featured drink on the winter menu.
- **House gin switched from Fords to Tanqueray** — updated the base-spirits ingredient (new slug + cost per oz) and every cocktail referencing it (Alaska, Bramble, Count Mast, Forest Spirit, French 75, G&T, Gin Basil Smash, Last Word, Loggy Cab, Martini, Moonwell, Negroni, Negroni Bianco Bergamotto, Ramos Gin Fizz, Saturn, Singapore Sling).
- **Night Flight reworked** — rebuilt the spec around Tanqueray with a lavender-forward build, orange bitters, a lavender sprig garnish, and a herbal flavor tag.
- **Winter menu shuffled** — Rudolph's Nose joins the featured drinks, Merry Mule moves to Mommy's Drinks, and Penicillin replaces Jack Rose on Cyrus' Drinks.
- **Cocktail paths reworked** — Bard swaps Shark's Tooth for Painkiller; Royal now opens on a French 75 and drops Painkiller. Both descriptions rewritten to match the new lineups.
- Egg cost per oz corrected, and the PR authentication note in `CLAUDE.md` fixed to reference `GH_TOKEN`.

## Test plan

- [x] `npm run lint` passes
- [ ] `npm run test` — `src/routes/page.svelte.test.ts` fails to collect with `localStorage` undefined in the client workspace (`costMode.ts:11`). Pre-existing environment issue, unrelated to these data-only changes.
- [ ] Spot-check `/cocktails/rudolphs-nose`, `/winter-menu`, `/paths/bard`, and `/paths/royal` in the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)