### PR TITLE
feat(recipes): standardize base spirit specs and refine infusions

### DIFF
--- a/src/lib/data/cocktails/night-flight.ts
+++ b/src/lib/data/cocktails/night-flight.ts
@@ -8,7 +8,7 @@ import AARON_KRAUSS from '$lib/data/bartenders/aaron-krauss';
 
 const NIGHT_FLIGHT: Cocktail = {
 	title: 'Night Flight',
-	description: 'Gin, lemon, maraschino, lavender, and dark berry liqueur.',
+	description: 'Gin, lavender liqueur, dark berry liqueur, lemon, simple syrup, orange bitters.',
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/cocktails/full/night-flight.png',
 	thumbnailImagePath:
@@ -25,7 +25,7 @@ const NIGHT_FLIGHT: Cocktail = {
 			ingredient: Ingredients.BaseSpirits.TANQUERAY
 		},
 		{
-			amount: '.75oz',
+			amount: '.5oz',
 			ingredient: Ingredients.Liqueurs.LAVENDER_LIQUEUR
 		},
 		{
@@ -33,8 +33,12 @@ const NIGHT_FLIGHT: Cocktail = {
 			ingredient: Ingredients.Liqueurs.HOUSE_DARK_BERRY_CREME
 		},
 		{
-			amount: '.5oz',
+			amount: '.75oz',
 			ingredient: Ingredients.Citrus.LEMON
+		},
+		{
+			amount: '.25oz',
+			ingredient: Ingredients.Syrups.RICH_SIMPLE_SYRUP
 		},
 		{
 			amount: '1 dash',

--- a/src/lib/data/recipes/aquavit.ts
+++ b/src/lib/data/recipes/aquavit.ts
@@ -5,8 +5,7 @@ const AQUAVIT: Recipe = {
 	slug: 'aquavit',
 	description: 'Nordic spirit flavored with caraway, dill, and botanicals.',
 	ingredients: [
-		'4oz Everclear (95% ABV grain liquor)',
-		'5oz Distilled Water',
+		'9oz 40% ABV Vodka',
 		'1.25 tsp Caraway seed',
 		'.5 tsp Dill seed',
 		'.5 tsp Coriander seed',

--- a/src/lib/data/recipes/caramel-vodka.ts
+++ b/src/lib/data/recipes/caramel-vodka.ts
@@ -4,7 +4,7 @@ const CARAMEL_VODKA: Recipe = {
 	name: 'Caramel Vodka',
 	slug: 'caramel-vodka',
 	description: 'Vodka infused with homemade caramel syrup for a sweet, rich flavor.',
-	ingredients: ['1 oz caramel syrup (see recipe)', '3 oz vodka'],
+	ingredients: ['3oz 40% ABV Vodka', '1oz Caramel Syrup (see recipe)'],
 	instructions: 'Mix ingredients together. Easy as that!',
 	notes:
 		'Because the caramel syrup has no fat, this infusion will maintain a nice, translucent color with no separation.'

--- a/src/lib/data/recipes/citron-vodka.ts
+++ b/src/lib/data/recipes/citron-vodka.ts
@@ -4,7 +4,7 @@ const CITRON_VODKA: Recipe = {
 	name: 'Citron Vodka',
 	slug: 'citron-vodka',
 	description: 'Vodka infused with lemon peel.',
-	ingredients: ['8 oz vodka', 'Peels of 1 lemon'],
+	ingredients: ['8oz 40% ABV Vodka', 'Peels of 1 lemon'],
 	instructions:
 		'Add ingredients to a mason jar and let infuse for 48-72 hours, swirling a few times a day. Strain.'
 };

--- a/src/lib/data/recipes/creme-de-cacao.ts
+++ b/src/lib/data/recipes/creme-de-cacao.ts
@@ -6,13 +6,13 @@ const CREME_DE_CACAO: Recipe = {
 	description: 'A chocolate-flavored liqueur made from cacao nibs.',
 	ingredients: [
 		'4oz (by weight) Cacao Nibs',
-		'6oz Everclear (95% ABV grain liquor)',
-		'6.8oz Distilled Water',
+		'6oz 95% ABV Grain Liquor',
+		'7oz Distilled Water',
 		'10oz 1:1 Simple Syrup'
 	],
 	instructions:
-		'Toast cacao nibs in air fryer or oven for 5 minutes. Let cool. Infuse cacao nibs in everclear for 7-10 days. Strain out cacao nibs. Add simple syrup and water. Let rest for 5 days.',
-	notes: 'Makes ~20-22oz at ~25% ABV. Takes a couple of weeks to make.'
+		'Toast the cacao nibs at 275–300°F for approximately 5 minutes, shaking once, until fragrant. Allow them to cool completely. Combine the cacao nibs, grain liquor, and 4 oz distilled water. Infuse for 7–10 days, shaking gently once daily and tasting beginning around day five. Strain thoroughly without aggressively squeezing the nibs. Add the simple syrup and remaining 3 oz distilled water. Bottle and let rest for 10–14 days.',
+	notes: 'Makes ~20-22oz at ~23-26% ABV. Takes a couple of weeks to make.'
 };
 
 export default CREME_DE_CACAO;

--- a/src/lib/data/recipes/dry-curacao.ts
+++ b/src/lib/data/recipes/dry-curacao.ts
@@ -5,18 +5,18 @@ const DRY_CURACAO: Recipe = {
 	slug: 'dry-curacao',
 	description: 'Bright, dry orange liqueur with subtle bitterness.',
 	ingredients: [
-		'Peels from 5 navel oranges, unwaxed (no white pithe)',
+		'Peels from 3 navel oranges, unwaxed (no white pithe)',
 		'Peels from 1/2 lemon, unwaxed (no white pithe)',
-		'Peels from 3/4 grapefruit, unwaxed (no white pithe)',
-		'300mL Everclear (95% ABV grain liquor)',
+		'2"x1" grapefruit peel, unwaxed (no white pithe)',
+		'300mL 95% ABV Grain Liquor',
 		'250mL Brandy',
-		'1tsp coriander seeds, lightly crushed',
+		'3/4 tsp coriander seeds, lightly crushed',
 		'1/2 cinnamon stick',
 		'140g Granulated Sugar',
 		'320mL Water'
 	],
 	instructions:
-		'Infuse all besides sugar and water in a glass jar for 7-10 days. Strain. Heat water and sugar to make syrup, let cool, and add to infusion. Let rest 3 weeks.',
+		'Infuse orange, lemon, and grapefruit peels with grain liquor and brandy in a glass jar for 7 days. On day 4, add cinnamon stick and coriander seeds. After full 7 days, strain. Heat water and sugar to make syrup, let cool, and add to infusion. Let rest 3 weeks.',
 	notes: 'Makes ~950mL at 40% ABV.'
 };
 

--- a/src/lib/data/recipes/house-dark-berry-creme.ts
+++ b/src/lib/data/recipes/house-dark-berry-creme.ts
@@ -5,16 +5,17 @@ const HOUSE_DARK_BERRY_CREME: Recipe = {
 	slug: 'house-dark-berry-creme',
 	description: 'A rich berry liqueur infused with vodka, lemon peel, and Ceylon black tea.',
 	ingredients: [
-		'300g blueberries',
-		'200g blackberries',
+		'250g blueberries',
+		'250g blackberries',
 		'50g raspberries',
-		'400mL vodka (40-50% ABV)',
+		'400mL 50% ABV Vodka',
 		'225g granulated sugar',
-		'2 strips lemon peel (no pith)',
-		'0.3g Ceylon black tea leaves'
+		'2 2"x1" strips lemon peel (washed, unwaxed, no pith)',
+		'1g Ceylon black tea leaves',
+		'2tsp lemon juice'
 	],
 	instructions:
-		'Lightly crush all fruit in a jar. Add vodka, lemon peel, and tea leaves. Seal and shake. Let macerate for 2 weeks, shaking occasionally. Strain through fine mesh, then strain again through cheesecloth or a coffee filter. Stir in sugar until fully dissolved. Bottle and rest for 1-2 weeks before using.',
+		'Lightly crush all fruit in a jar. Add vodka and lemon peel. Seal and shake. Let macerate for 14 days, shaking occasionally. On day 12, add tea leaves. Strain through fine mesh, then strain again through cheesecloth or a coffee filter. Stir in sugar and lemon juice until fully dissolved. Bottle and rest for 1-2 weeks before using.',
 	notes:
 		'Store sealed in the refrigerator or a cool, dark place. Best after 2-4 weeks; keeps well for up to 1 year.'
 };

--- a/src/lib/data/recipes/lavender-liqueur.ts
+++ b/src/lib/data/recipes/lavender-liqueur.ts
@@ -5,15 +5,13 @@ const LAVENDER_LIQUEUR: Recipe = {
 	slug: 'lavender-liqueur',
 	description: 'A floral liqueur made by infusing lavender into grain alcohol.',
 	ingredients: [
-		'2oz Everclear (190 proof)',
-		'3oz Water',
+		'5oz 40% ABV Vodka',
 		'1 tsp dried culinary lavender petals (or 1 tbsp fresh)',
-		'2oz Simple Syrup (1:1)',
-		'Optional: small strip lemon peel (no white pith)'
+		'2oz Simple Syrup (1:1)'
 	],
 	instructions:
-		'Steep everything but the syrup for 12 hours. Strain out the solids, then add the syrup.',
-	notes: 'Makes ~7oz at 27% ABV.'
+		'Steep vodka and lavender for 12 hours. Strain out the solids, then add the simple syrup.',
+	notes: 'Makes ~7oz at 28% ABV.'
 };
 
 export default LAVENDER_LIQUEUR;

--- a/src/lib/data/recipes/limoncello.ts
+++ b/src/lib/data/recipes/limoncello.ts
@@ -5,14 +5,14 @@ const LIMONCELLO: Recipe = {
 	slug: 'limoncello',
 	description: 'A classic Italian liqueur made from lemons.',
 	ingredients: [
-		'Peels from 5 lemons, unwaxed (no white pithe)',
-		'1C Everclear (95% ABV grain liquor)',
+		'Peels from 5 lemons, washed, unwaxed (no white pithe)',
+		'1C 95% ABV Grain Liquor',
 		'1.5C Water',
 		'200g Sugar'
 	],
 	instructions:
-		'Infuse everclear and lemon peels for 2 weeks or more (lower end if more white pithe). Heat water and sugar to make syrup. Strain lemon peels out, add syrup. Let rest for at least 5 days in freezer.',
-	notes: 'Makes ~24oz at 31% ABV. Takes a few weeks to make. Always serve chilled.'
+		'Infuse grain liquor and lemon peels for 3 weeks. Heat water and sugar to make syrup, and let cool. Strain lemon peels out, add syrup. Let rest for 2 weeks.',
+	notes: 'Makes ~24oz at 31% ABV. Traditionally served straight from the freezer.'
 };
 
 export default LIMONCELLO;

--- a/src/lib/data/recipes/peppermint-vodka.ts
+++ b/src/lib/data/recipes/peppermint-vodka.ts
@@ -4,7 +4,7 @@ const PEPPERMINT_VODKA: Recipe = {
 	name: 'Peppermint Vodka',
 	slug: 'peppermint-vodka',
 	description: 'Vodka infused with peppermint candies for a festive, minty spirit.',
-	ingredients: ['4 oz vodka', '2 hard peppermint candies (the ones with the red swirls)'],
+	ingredients: ['4oz 40% ABV Vodka', '2 hard peppermint candies (the ones with the red swirls)'],
 	instructions:
 		'Add ingredients to a mason jar and let infuse for 2-3 hours, swirling around every 15-30 minutes. Remove any lingering pieces.',
 	notes: 'Used in the Peppermint Espresso Martini. This infusion will turn a nice pink/red color.'

--- a/src/lib/data/recipes/persian-spice-liqueur.ts
+++ b/src/lib/data/recipes/persian-spice-liqueur.ts
@@ -5,16 +5,16 @@ const PERSIAN_SPICE_LIQUEUR: Recipe = {
 	slug: 'persian-spice-liqueur',
 	description: 'A spiced liqueur with notes of cardamom, rose, and vanilla.',
 	ingredients: [
-		'250mL Everclear',
-		'400mL distilled water',
+		'2.5C 40% ABV Vodka',
 		'10g edible rose petals',
 		'2 cardamom pods, cracked',
 		'1/2 vanilla bean, split and scraped',
-		'250g Sugar'
+		'250g sugar',
+		'1/4C distilled water'
 	],
 	instructions:
-		'Steep everclear, 250mL water, rose petals, cardamom pods, and vanilla bean in a mason jar for 24 hours, swirling every few hours. Strain. Heat remaining 150mL water and sugar until dissolved. Combine with alcohol and let rest for at least 5 days.',
-	notes: 'Makes ~750mL at 31% ABV. Best stored in the freezer.'
+		'Combine the vodka, rose petals, cracked cardamom pods, and vanilla bean—including the scraped seeds—in a mason jar. Seal and steep for 24 hours, swirling every few hours. Strain through a fine-mesh strainer. For a clearer liqueur, strain again through cheesecloth or a coffee filter. Add the sugar and distilled water directly to the strained infusion. Seal and shake thoroughly. Continue shaking periodically until the sugar is completely dissolved, allowing it to sit overnight if necessary. Bottle and let rest for at least 5 days before using.',
+	notes: 'Makes ~750mL at 31% ABV.'
 };
 
 export default PERSIAN_SPICE_LIQUEUR;

--- a/src/lib/data/recipes/stone-fruit-liqueur.ts
+++ b/src/lib/data/recipes/stone-fruit-liqueur.ts
@@ -5,18 +5,17 @@ const STONE_FRUIT_LIQUEUR: Recipe = {
 	slug: 'stone-fruit-liqueur',
 	description: 'A house liqueur with notes of ripe peach and apricot.',
 	ingredients: [
-		'250 ml 95% ABV neutral spirit',
-		'200 ml water',
-		'250 g peach, chopped, with skin',
-		'150 g apricot, chopped, with skin',
-		'300 g sugar',
-		'.5 oz amaretto',
-		'1 strip lemon peel, with minimal white pith',
+		'450ml 50% ABV Vodka',
+		'250g peach, chopped, with skin',
+		'150g apricot, chopped, with skin',
+		'300g sugar',
+		'.5oz amaretto',
+		'1 2"x1" strip lemon peel, washed, unwaxed, with minimal white pith',
 		'2 tsp lemon juice',
 		'Tiny pinch of salt'
 	],
 	instructions:
-		'Combine the 95% ABV spirit with the water to make about 450 ml of diluted spirit at roughly 53% ABV. In a clean jar, combine the chopped peach, chopped apricot, and sugar, then refrigerate for 24 hours to macerate. Add the diluted spirit and lemon peel, then infuse for 5-8 days, tasting toward the end of that window. Strain and fine-strain the liqueur, then stir in the amaretto, lemon juice, and a tiny pinch of salt. Let rest for 1-2 weeks before using.',
+		'In a clean jar, combine the chopped peach, chopped apricot, and sugar, then refrigerate for 24 hours to macerate. Add the vodka, lemon peel, then infuse for 5-8 days, tasting toward the end of that window. Strain and fine-strain the liqueur, then stir in the amaretto, lemon juice, and a tiny pinch of salt. Let rest for 1-2 weeks before using.',
 	notes: 'Refrigerate for best quality.'
 };
 

--- a/src/lib/utils/spirit-dilution.ts
+++ b/src/lib/utils/spirit-dilution.ts
@@ -3,7 +3,9 @@ export const ML_PER_FL_OZ = 29.575;
 const DENSITY_TABLE: ReadonlyArray<readonly [number, number]> = [
 	[20, 0.974],
 	[40, 0.948],
-	[70, 0.867],
+	[45, 0.94],
+	[50, 0.93],
+	[70, 0.886],
 	[95, 0.811],
 	[100, 0.789]
 ];


### PR DESCRIPTION
## Summary

- **Base spirits restated by ABV** across the house recipes instead of brand-name-plus-water dilution (`Everclear` + distilled water → e.g. `9oz 40% ABV Vodka`, `95% ABV Grain Liquor`). Touches Aquavit, Caramel Vodka, Citron Vodka, Crème de Cacao, Dry Curaçao, House Dark Berry Crème, Lavender Liqueur, Limoncello, Peppermint Vodka, Persian Spice Liqueur, and Stone Fruit Liqueur.
- **Infusion specs tightened** — adjusted quantities and timings, and expanded the terse instructions into step-by-step procedures for Crème de Cacao, Dry Curaçao, House Dark Berry Crème, and Persian Spice Liqueur (staged additions like adding tea leaves on day 12 and cinnamon/coriander on day 4, explicit strain and rest windows, toasting temperatures).
- **Night Flight rebalanced** — lavender liqueur down to .5oz, lemon up to .75oz, plus .25oz rich simple syrup; description updated to match the build.
- **Spirit dilution densities** — added 45% and 50% ABV entries to `DENSITY_TABLE` and corrected the 70% value from 0.867 to 0.886, so the new 50% ABV recipe specs interpolate accurately.

## Test plan

- [x] `npm run lint` passes
- [ ] `npm run test` — `src/routes/page.svelte.test.ts` fails to collect with `localStorage` undefined in the client workspace (`costMode.ts:11`). Pre-existing environment issue, unrelated to these data changes.
- [ ] Spot-check the affected `/recipes/[slug]` pages and `/cocktails/night-flight` in the dev server, and confirm cost calculations still look right for the recipes that switched ABV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)