### PR TITLE
feat(recipes): revise curacao and lavender specs, swap Royal path opener

### DIFF
--- a/src/lib/data/cocktail-paths/royal.ts
+++ b/src/lib/data/cocktail-paths/royal.ts
@@ -1,8 +1,8 @@
 import type { CocktailPath } from '$lib/types/cocktail-path';
 import CHOCOLATE_COVERED_CHERRIES from '../cocktails/chocolate-covered-cherries';
-import FRENCH_75 from '../cocktails/french-75';
 import KING_OF_KINGS from '../cocktails/king-of-kings';
 import RAMOS_GIN_FIZZ from '../cocktails/ramos-gin-fizz';
+import RUDOLPHS_NOSE from '../cocktails/rudolphs-nose';
 import SINGAPORE_SLING from '../cocktails/singapore-sling';
 
 export const ROYAL: CocktailPath = {
@@ -12,6 +12,12 @@ export const ROYAL: CocktailPath = {
 	imagePath:
 		'https://personal-k8s-main-space.nyc3.cdn.digitaloceanspaces.com/thekrausshaus.com/images/paths/royal.jpeg',
 	description:
-		'Every sip should feel like an indulgence. This path opens on a champagne toast, escalates into a lavish multi-spirit tiki blend, moves through a cascade of fruit and liqueur, then dips into a dessert you can drink before finishing with a velvety, cream-topped crown jewel. These are drinks that reward you for going all in.',
-	cocktails: [FRENCH_75, KING_OF_KINGS, SINGAPORE_SLING, CHOCOLATE_COVERED_CHERRIES, RAMOS_GIN_FIZZ]
+		'Every sip should feel like an indulgence. This path opens on a ruby-red tropical sour, escalates into a lavish multi-spirit tiki blend, moves through a cascade of fruit and liqueur, then dips into a dessert you can drink before finishing with a velvety, cream-topped crown jewel. These are drinks that reward you for going all in.',
+	cocktails: [
+		RUDOLPHS_NOSE,
+		KING_OF_KINGS,
+		SINGAPORE_SLING,
+		CHOCOLATE_COVERED_CHERRIES,
+		RAMOS_GIN_FIZZ
+	]
 };

--- a/src/lib/data/recipes/dry-curacao.ts
+++ b/src/lib/data/recipes/dry-curacao.ts
@@ -5,19 +5,20 @@ const DRY_CURACAO: Recipe = {
 	slug: 'dry-curacao',
 	description: 'Bright, dry orange liqueur with subtle bitterness.',
 	ingredients: [
-		'Peels from 3 navel oranges, unwaxed (no white pithe)',
-		'Peels from 1/2 lemon, unwaxed (no white pithe)',
-		'2"x1" grapefruit peel, unwaxed (no white pithe)',
-		'300mL 95% ABV Grain Liquor',
+		'Peels from 3 navel oranges, unwaxed (no white pith)',
+		'Peels from 1/2 lemon, unwaxed (no white pith)',
+		'2"x1" grapefruit peel, unwaxed (no white pith)',
+		'570mL 50% ABV Vodka',
 		'250mL Brandy',
-		'3/4 tsp coriander seeds, lightly crushed',
+		'1/2 tsp coriander seeds, lightly crushed',
 		'1/2 cinnamon stick',
-		'140g Granulated Sugar',
-		'320mL Water'
+		'150g Granulated Sugar',
+		'50mL Water'
 	],
 	instructions:
-		'Infuse orange, lemon, and grapefruit peels with grain liquor and brandy in a glass jar for 7 days. On day 4, add cinnamon stick and coriander seeds. After full 7 days, strain. Heat water and sugar to make syrup, let cool, and add to infusion. Let rest 3 weeks.',
-	notes: 'Makes ~950mL at 40% ABV.'
+		'Infuse orange, lemon, and grapefruit peels with vodka and brandy in a glass jar for 10 days. On day 7, add cinnamon stick and coriander seeds. After the full 10 days, strain. Add the water and sugar to the strained infusion. Seal and shake vigorously. Let stand for 24–48 hours, shaking occasionally until all of the sugar has dissolved. Let rest at least 3 weeks, preferably 4 weeks.',
+	notes:
+		'Makes approximately 950 mL at ~40% ABV. Best after 3–4 weeks; continues to improve for 2–3 months.'
 };
 
 export default DRY_CURACAO;

--- a/src/lib/data/recipes/lavender-liqueur.ts
+++ b/src/lib/data/recipes/lavender-liqueur.ts
@@ -6,7 +6,7 @@ const LAVENDER_LIQUEUR: Recipe = {
 	description: 'A floral liqueur made by infusing lavender into grain alcohol.',
 	ingredients: [
 		'5oz 40% ABV Vodka',
-		'1 tsp dried culinary lavender petals (or 1 tbsp fresh)',
+		'1.5 tsp dried culinary lavender petals (or 1 tbsp fresh)',
 		'2oz Simple Syrup (1:1)'
 	],
 	instructions:


### PR DESCRIPTION
## Summary

- **Royal path** — replaced French 75 with Rudolph's Nose as the opening cocktail, and updated the path description to match ("a ruby-red tropical sour" instead of "a champagne toast").
- **Dry Curaçao** — reworked the spec: 570mL 50% ABV vodka in place of 300mL 95% grain liquor, coriander down to 1/2 tsp, sugar up to 150g with water down to 50mL, and a 10-day infusion (spices added day 7) with a shake-to-dissolve step instead of a cooked syrup. Notes now call out the 3–4 week rest and continued improvement over 2–3 months. Also fixed "pithe" → "pith".
- **Lavender Liqueur** — bumped dried lavender from 1 tsp to 1.5 tsp.

## Test plan

- [ ] `npm run lint`
- [ ] `npm run check`
- [ ] Spot-check `/paths/royal`, `/recipes/dry-curacao`, and `/recipes/lavender-liqueur` render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)